### PR TITLE
perf: run pushes via RQ with backpressure and locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,19 +385,44 @@ Labels come from `attributes.Label` (or `attributes.label`) in localizations.
 
 `POST /sync-to-tator` pushes FiftyOne dataset edits (labels, confidence) back to Tator localizations. Run after editing in the FiftyOne app.
 
+The endpoint is **asynchronous**: it enqueues an RQ job and returns immediately so a long bulk PATCH loop against Tator cannot block other HTTP requests. The RQ worker (`python -m src.app.sync_worker`) executes the push. Requires Redis (set `REDIS_HOST` or `REDIS_URL`).
+
 | Param | Required | Description |
 |-------|----------|-------------|
 | `project_id` | yes | Tator project ID |
 | `version_id` | yes | Tator version ID (localizations must be in this version) |
 | `api_url` | yes | Tator REST API base URL |
 | `token` | yes | Tator API token |
+| `port` | yes | Port for this project (resolves database) |
 | `dataset_name` | no | FiftyOne dataset name (default: `project_name_v{version_id}_{port}`) |
+| `label_attr` | no | Tator attribute name for label (default `Label`) |
+| `score_attr` | no | Tator attribute name for score/confidence; omit to skip |
+| `force_sync` | no | Push all samples regardless of timestamps |
 
 ```bash
-curl -X POST "http://localhost:8001/sync-to-tator?project_id=4&version_id=1&api_url=https://tator.example.com&token=YOUR_TOKEN"
+# 1. Enqueue
+curl -X POST "http://localhost:8001/sync-to-tator?project_id=4&version_id=1&port=5151&api_url=https://tator.example.com&token=YOUR_TOKEN"
+# {"job_id": "abc...", "status": "queued", "port": 5151}
+
+# 2. Poll status (queued|started|finished|failed)
+curl "http://localhost:8001/sync-to-tator/status/abc..."
+# when finished: {"status": "finished", "result": {"status": "ok", "updated": N, "skipped": K, "failed": M, "errors": [...]}}
+
+# 3. Tail logs while running
+curl "http://localhost:8001/sync-to-tator/logs/abc..."
 ```
 
-Returns `{"status": "ok", "updated": N, "failed": M, "errors": [...]}`.
+Only one push runs at a time per `(database, project, version)`; a second push for the same target returns `{"status": "busy", ...}` instead of competing for Tator writes.
+
+**Backpressure tuning** (set on the sync service; restart to apply):
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `FIFTYONE_SYNC_TO_TATOR_FETCH_CHUNK` | `100` | Elemental-id resolve chunk size (PUT by ids) |
+| `FIFTYONE_SYNC_TO_TATOR_PATCH_CHUNK` | `100` | Bulk PATCH chunk size (`update_localization_list`) |
+| `FIFTYONE_SYNC_TO_TATOR_CHUNK_DELAY_MS` | `0` | Sleep between PATCH chunks in milliseconds to smooth write bursts |
+
+If Tator becomes unresponsive during pushes, lower the chunk sizes and/or raise the inter-chunk delay (for example `FIFTYONE_SYNC_TO_TATOR_PATCH_CHUNK=50`, `FIFTYONE_SYNC_TO_TATOR_CHUNK_DELAY_MS=200`).
 
 ## Embedding API Usage
 

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -686,10 +686,15 @@ async def sync_to_tator(
     ),
 ) -> dict:
     """
-    Push FiftyOne dataset edits (labels, confidence) back to Tator localizations.
-    Requires the dataset to exist (run POST /sync first). Uses elemental_id to match samples.
+    Enqueue a job that pushes FiftyOne dataset edits (labels, confidence) back to Tator
+    localizations. Returns immediately with {"job_id": ..., "status": "queued"}; poll
+    GET /sync-to-tator/status/{job_id} for progress. Requires the dataset to exist
+    (run POST /sync first) and Redis (REDIS_HOST or REDIS_URL).
+
+    Running async keeps the FastAPI worker free so a long bulk PATCH loop against
+    Tator cannot block other HTTP requests.
     """
-    from src.app.sync import sync_edits_to_tator
+    from src.app.sync_queue import enqueue_sync_to_tator
 
     project_name = None
     try:
@@ -702,23 +707,56 @@ async def sync_to_tator(
         logger.warning(f"sync_to_tator get_project({project_id}) failed: {e}")
     if not project_name or not str(project_name).strip():
         project_name = str(project_id)
+
     try:
-        result = sync_edits_to_tator(
+        job_id = enqueue_sync_to_tator(
             project_id=project_id,
             version_id=version_id,
-            port=port,
             api_url=_resolve_api_url(api_url),
             token=token,
+            port=port,
+            project_name=project_name.strip(),
             dataset_name=dataset_name,
             label_attr=label_attr,
             score_attr=score_attr,
             debug=debug,
-            project_name=project_name.strip(),
             force_sync=force_sync,
         )
-        return result
+        return {"job_id": job_id, "status": "queued", "port": port}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=503, detail=f"Redis unavailable: {e}") from e
+
+
+@app_launch.get("/sync-to-tator/status/{job_id}")
+async def sync_to_tator_status(job_id: str) -> dict:
+    """
+    Poll status of an enqueued sync-to-tator job. Returns status
+    (queued|started|finished|failed) and, when finished, the worker result
+    (status, updated, skipped, failed, errors). Requires Redis.
+    """
+    from src.app.sync_queue import get_job_status
+
+    try:
+        return get_job_status(job_id)
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"Redis unavailable: {e}") from e
+
+
+@app_launch.get("/sync-to-tator/logs/{job_id}")
+async def sync_to_tator_logs(job_id: str) -> dict:
+    """
+    Return log lines from the sync-to-tator worker for the given job (from job metadata).
+    Returns {"log_lines": list[str]}. Use while polling status to show progress in the applet.
+    """
+    from rq.exceptions import NoSuchJobError
+    from src.app.sync_queue import get_job_logs
+
+    try:
+        return get_job_logs(job_id)
+    except NoSuchJobError:
+        raise HTTPException(status_code=404, detail="Job not found") from None
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"Redis unavailable: {e}") from e
 
 
 @app_launch.get("/dataset-exists")

--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -39,6 +39,7 @@ from src.app.database_manager import (
 )
 from src.app.sync_lock import (
     get_sync_lock_key,
+    get_sync_to_tator_lock_key,
     release_sync_lock,
     try_acquire_sync_lock,
 )
@@ -59,9 +60,48 @@ _DEFAULT_LOCALIZATION_BATCH_SIZE = 5000
 # Each media_id in query string is ~17 bytes; base URL + version ~500; 150 * 17 + 500 < 4094.
 _MAX_SAFE_MEDIA_ID_BATCH_SIZE = 150
 
-# sync_edits_to_tator: batch LocalizationList PUT/PATCH (elemental_ids / bulk update)
-_SYNC_TO_TATOR_ELEMENTAL_FETCH_CHUNK = 500
-_SYNC_TO_TATOR_BULK_PATCH_CHUNK = 500
+# sync_edits_to_tator: batch LocalizationList PUT/PATCH (elemental_ids / bulk update).
+# Chunk sizes are tunable via env vars so production can throttle bursts that would
+# otherwise overwhelm the Tator API (defaults reduced from 500 to 100/100).
+# FIFTYONE_SYNC_TO_TATOR_FETCH_CHUNK: elemental-id resolve chunk size (PUT by ids).
+# FIFTYONE_SYNC_TO_TATOR_PATCH_CHUNK: bulk PATCH chunk size (update_localization_list).
+# FIFTYONE_SYNC_TO_TATOR_CHUNK_DELAY_MS: optional sleep between PATCH chunks (smooths writes).
+
+
+def _env_int(name: str, default: int, *, minimum: int = 1) -> int:
+    """Parse positive int env var; fall back to default on missing/invalid."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        val = int(raw)
+    except ValueError:
+        return default
+    return max(minimum, val)
+
+
+def _sync_to_tator_fetch_chunk() -> int:
+    return _env_int("FIFTYONE_SYNC_TO_TATOR_FETCH_CHUNK", 100, minimum=1)
+
+
+def _sync_to_tator_patch_chunk() -> int:
+    return _env_int("FIFTYONE_SYNC_TO_TATOR_PATCH_CHUNK", 100, minimum=1)
+
+
+def _sync_to_tator_chunk_delay_seconds() -> float:
+    """Inter-chunk sleep in seconds for bulk PATCH (0 disables)."""
+    raw = os.environ.get("FIFTYONE_SYNC_TO_TATOR_CHUNK_DELAY_MS", "").strip()
+    if not raw:
+        return 0.0
+    try:
+        ms = float(raw)
+    except ValueError:
+        return 0.0
+    return max(0.0, ms) / 1000.0
+
+
+_SYNC_TO_TATOR_ELEMENTAL_FETCH_CHUNK = 100
+_SYNC_TO_TATOR_BULK_PATCH_CHUNK = 100
 
 # Sample field storing Tator localization modified time (FiftyOne's last_modified_at is read-only)
 TATOR_MODIFIED_AT_FIELD = "tator_modified_at"
@@ -2355,14 +2395,15 @@ def _fetch_localizations_by_elemental_ids(
     version_id: int,
     elemental_ids: list[str],
     *,
-    chunk_size: int = _SYNC_TO_TATOR_ELEMENTAL_FETCH_CHUNK,
+    chunk_size: int | None = None,
 ) -> dict[str, Any]:
     """Resolve elemental_ids to localization objects via LocalizationList PUT (by-id query body)."""
     out: dict[str, Any] = {}
     if not elemental_ids:
         return out
+    effective_chunk = chunk_size if chunk_size is not None else _sync_to_tator_fetch_chunk()
     unique = list(dict.fromkeys(elemental_ids))
-    for chunk in _chunk_list(unique, chunk_size):
+    for chunk in _chunk_list(unique, effective_chunk):
         locs = api.get_localization_list_by_id(
             project_id,
             localization_id_query={"elemental_ids": chunk},
@@ -2383,11 +2424,15 @@ def _bulk_patch_localizations_by_elemental_id(
     version_id: int,
     elemental_id_to_attrs: dict[str, dict[str, Any]],
     loc_by_eid: dict[str, Any],
+    *,
+    chunk_size: int | None = None,
+    inter_chunk_delay_seconds: float | None = None,
 ) -> None:
     """
     Apply attribute updates using PATCH /rest/Localizations/{project} (bulk update).
     Groups by (localization type id, attribute payload) so each request satisfies Tator's
-    single-type requirement for bulk patch.
+    single-type requirement for bulk patch. Adds a small inter-chunk sleep (configurable
+    via FIFTYONE_SYNC_TO_TATOR_CHUNK_DELAY_MS) to smooth write bursts against Tator.
     """
     groups: dict[tuple[int, tuple[tuple[str, Any], ...]], list[str]] = defaultdict(list)
     missing: list[str] = []
@@ -2404,9 +2449,30 @@ def _bulk_patch_localizations_by_elemental_id(
         suffix = "..." if len(missing) > 10 else ""
         raise ValueError(f"No localization found for elemental_id(s): {preview}{suffix}")
 
+    effective_chunk = chunk_size if chunk_size is not None else _sync_to_tator_patch_chunk()
+    effective_delay = (
+        inter_chunk_delay_seconds
+        if inter_chunk_delay_seconds is not None
+        else _sync_to_tator_chunk_delay_seconds()
+    )
+    total_chunks = sum(
+        max(1, (len(eids) + effective_chunk - 1) // effective_chunk)
+        for _g, eids in groups.items()
+    )
+    logger.info(
+        "sync_edits_to_tator: bulk PATCH groups=%s total_chunks=%s chunk_size=%s "
+        "inter_chunk_delay_ms=%s",
+        len(groups),
+        total_chunks,
+        effective_chunk,
+        int(effective_delay * 1000),
+    )
+
+    sent_chunks = 0
     for (_tid, key), eids in groups.items():
         attrs = dict(key)
-        for chunk in _chunk_list(eids, _SYNC_TO_TATOR_BULK_PATCH_CHUNK):
+        chunks = list(_chunk_list(eids, effective_chunk))
+        for i, chunk in enumerate(chunks):
             api.update_localization_list(
                 project_id,
                 localization_bulk_update={
@@ -2416,6 +2482,9 @@ def _bulk_patch_localizations_by_elemental_id(
                 },
                 version=[version_id],
             )
+            sent_chunks += 1
+            if effective_delay > 0 and (i + 1) < len(chunks):
+                time.sleep(effective_delay)
 
 
 def sync_edits_to_tator(
@@ -2514,6 +2583,59 @@ def sync_edits_to_tator(
         )
     ds_name = resolved
 
+    push_lock_key = get_sync_to_tator_lock_key(db_name, project_id, version_id)
+    logger.info(
+        f"Acquiring sync-to-tator lock: key={push_lock_key} "
+        f"(db={db_name}, project_id={project_id}, version_id={version_id})"
+    )
+    if not try_acquire_sync_lock(push_lock_key):
+        logger.warning(
+            f"Failed to acquire sync-to-tator lock: key={push_lock_key} - "
+            "another push is in progress"
+        )
+        return {
+            "status": "busy",
+            "message": (
+                "Another sync-to-tator push is already running for this version. "
+                "Please try again in a few minutes."
+            ),
+            "updated": 0,
+            "skipped": 0,
+            "failed": 0,
+            "errors": [],
+        }
+
+    try:
+        return _do_sync_edits_to_tator(
+            api=api,
+            project_id=project_id,
+            version_id=version_id,
+            ds_name=ds_name,
+            label_attr=label_attr,
+            score_attr=score_attr,
+            debug=debug,
+            force_sync=force_sync,
+        )
+    finally:
+        logger.info(f"Releasing sync-to-tator lock: key={push_lock_key}")
+        try:
+            release_sync_lock(push_lock_key)
+        except Exception as e:  # pragma: no cover - best-effort release
+            logger.warning(f"Failed to release sync-to-tator lock {push_lock_key}: {e}")
+
+
+def _do_sync_edits_to_tator(
+    *,
+    api: Any,
+    project_id: int,
+    version_id: int,
+    ds_name: str,
+    label_attr: str | None,
+    score_attr: str | None,
+    debug: bool,
+    force_sync: bool,
+) -> dict[str, Any]:
+    """Inner push routine; the public wrapper handles DB selection and locking."""
     dataset = fo.load_dataset(ds_name)
 
     updated = 0
@@ -2670,6 +2792,74 @@ def run_sync_job(
             vss_project_key=vss_project_key,
             s3_bucket=s3_bucket,
             s3_prefix=s3_prefix,
+        )
+    finally:
+        if job_meta_handler is not None:
+            try:
+                logger.removeHandler(job_meta_handler)
+                job_meta_handler.close()
+            except Exception:
+                pass
+
+
+def run_sync_to_tator_job(
+    project_id: int,
+    version_id: int,
+    api_url: str,
+    token: str,
+    port: int,
+    project_name: str,
+    dataset_name: str | None = None,
+    label_attr: str = "Label",
+    score_attr: str | None = None,
+    debug: bool = False,
+    force_sync: bool = False,
+) -> dict[str, Any]:
+    """
+    Entrypoint for RQ worker: push FiftyOne edits back to Tator.
+
+    Running in the worker keeps long bulk PATCH loops off the HTTP event loop so the
+    FastAPI service stays responsive even when pushing thousands of localizations.
+    Attaches a job.meta log handler so the launcher applet can poll for progress.
+    """
+    from src.app.database_manager import register_project_id_name
+
+    logger.info(
+        "run_sync_to_tator_job received project_id=%s version_id=%s port=%s "
+        "dataset_name=%r force_sync=%s",
+        project_id,
+        version_id,
+        port,
+        dataset_name,
+        force_sync,
+    )
+
+    job_meta_handler: logging.Handler | None = None
+    try:
+        from rq import get_current_job
+
+        job = get_current_job()
+        if job is not None:
+            job_meta_handler = _JobMetaLogHandler(job)
+            job_meta_handler.setLevel(logging.DEBUG)
+            logger.addHandler(job_meta_handler)
+    except Exception:  # rq not installed or no worker context
+        pass
+
+    try:
+        register_project_id_name(project_id, project_name)
+        return sync_edits_to_tator(
+            project_id=project_id,
+            version_id=version_id,
+            port=port,
+            api_url=api_url,
+            token=token,
+            dataset_name=dataset_name,
+            label_attr=label_attr,
+            score_attr=score_attr,
+            debug=debug,
+            project_name=project_name,
+            force_sync=force_sync,
         )
     finally:
         if job_meta_handler is not None:

--- a/src/app/sync_lock.py
+++ b/src/app/sync_lock.py
@@ -62,6 +62,20 @@ def get_sync_lock_key(resolved_db: str, project_id: int, version_id: int | None)
     return f"{LOCK_KEY_PREFIX}:{resolved_db}:{project_id}:{_version_slug(version_id)}"
 
 
+def get_sync_to_tator_lock_key(
+    resolved_db: str, project_id: int, version_id: int | None
+) -> str:
+    """Return a unique key for a sync-to-tator (push) target.
+
+    Separate from ingest lock so an in-flight ingest does not block a push for the
+    same version (and vice versa); two pushes for the same target are mutually
+    exclusive. Shares the same prefix so `cleanup_all_sync_locks()` covers it.
+    """
+    return (
+        f"{LOCK_KEY_PREFIX}:push:{resolved_db}:{project_id}:{_version_slug(version_id)}"
+    )
+
+
 def try_acquire_sync_lock(
     lock_key: str,
     ttl_seconds: int = DEFAULT_TTL_SECONDS,

--- a/src/app/sync_queue.py
+++ b/src/app/sync_queue.py
@@ -93,6 +93,48 @@ def enqueue_sync(
     return job.id
 
 
+def enqueue_sync_to_tator(
+    project_id: int,
+    version_id: int,
+    api_url: str,
+    token: str,
+    port: int,
+    project_name: str,
+    dataset_name: str | None = None,
+    label_attr: str = "Label",
+    score_attr: str | None = None,
+    debug: bool = False,
+    force_sync: bool = False,
+) -> str:
+    """
+    Enqueue a sync-to-tator job (push FiftyOne edits back to Tator). Returns RQ job id.
+    Heavy bulk-patch work runs in the RQ worker so the HTTP handler is non-blocking
+    and a slow push cannot starve the API. Requires Redis.
+    """
+    from rq import Queue
+
+    conn = get_connection()
+    queue = Queue(QUEUE_NAME, connection=conn)
+    job = queue.enqueue(
+        "src.app.sync.run_sync_to_tator_job",
+        project_id=project_id,
+        version_id=version_id,
+        api_url=api_url,
+        token=token,
+        port=port,
+        project_name=project_name,
+        dataset_name=dataset_name,
+        label_attr=label_attr,
+        score_attr=score_attr,
+        debug=debug,
+        force_sync=force_sync,
+        job_timeout=3600 * 6,  # up to 6h for very large pushes
+        result_ttl=3600 * 24,
+        failure_ttl=3600,
+    )
+    return job.id
+
+
 def enqueue_dimreduce(
     project_id: int,
     version_id: int,


### PR DESCRIPTION
Move POST /sync-to-tator off the FastAPI event loop by enqueuing an RQ job (run_sync_to_tator_job) so bulk PATCH loops against Tator no longer block HTTP requests. Lower default fetch/patch chunk sizes from 500 to 100 and make them tunable via FIFTYONE_SYNC_TO_TATOR_FETCH_CHUNK, FIFTYONE_SYNC_TO_TATOR_PATCH_CHUNK, and FIFTYONE_SYNC_TO_TATOR_CHUNK_DELAY_MS to smooth write bursts that were making Tator unresponsive. Add /sync-to-tator/status/{job_id} and /sync-to-tator/logs/{job_id} for client polling, and a per-(db, project, version) push lock so duplicate pushes return busy instead of competing for Tator writes.