### PR TITLE
feat(sync): queue crop recompute and improve sync throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ flowchart TD
   - `GET /launch` - Allocate port, return FiftyOne App URL
   - `POST /sync` - Enqueue Tator-to-FiftyOne sync (requires Redis): fetch media + localizations, crop, build FiftyOne dataset, launch app. Returns `job_id` immediately; poll `GET /sync/status/{job_id}` for completion.
   - `GET /sync/status/{job_id}` - Poll status of a queued sync job.
+  - `POST /recompute-crops` - Enqueue a crop-only recompute job for an existing project/version. With `force=true`, recompute all localizations (overwrite existing crop files) and refresh `crop_manifest.json`; with `force=false`, recompute cache misses only.
+  - `GET /recompute-crops/status/{job_id}` - Poll status of a queued crop-recompute job.
+  - `GET /recompute-crops/logs/{job_id}` - Return worker log lines for a crop-recompute job.
   - `POST /sync-to-tator` - Push FiftyOne dataset edits (labels, confidence) back to Tator localizations
   - `GET /versions` - Return Tator versions for a project (query params: `project_id`, `api_url`; token via `Authorization: Token <token>` header only)
   - FiftyOne opens in a **new browser tab** (not in an iframe). Set **`iframe_host`** to the host where the FiftyOne app runs so the Open FiftyOne URL is correct (e.g. same host as Tator or `localhost`).

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -660,6 +660,104 @@ async def dimreduce_logs(job_id: str) -> dict:
         ) from e
 
 
+@app_launch.post("/recompute-crops")
+async def recompute_crops(
+    project_id: int = Query(..., description="Tator project ID"),
+    version_id: int = Query(..., description="Tator version ID"),
+    api_url: str = Query(..., description="Tator REST API base URL"),
+    token: str = Query(..., description="Tator API token"),
+    port: int = Query(..., description="Port for this project"),
+    force: bool = Query(
+        False,
+        description="When True, recompute all crops (overwrite existing files and refresh manifest)",
+    ),
+    force_sync: bool = Query(
+        False,
+        description="When True, refetch localizations instead of using recent local JSONL cache",
+    ),
+    vss_project_key: str | None = Query(
+        None, description="Optional VSS project key (for multi-VSS projects)"
+    ),
+    s3_bucket: str | None = Query(
+        None,
+        description="Optional S3 bucket for crop image sync (crops dir only, not full images)",
+    ),
+    s3_prefix: str | None = Query(
+        None, description="Optional S3 prefix (folder) for crop image sync"
+    ),
+) -> dict:
+    """
+    Enqueue a crop-recompute job for this project/version.
+    Returns immediately with {"job_id": ..., "status": "queued"}; poll
+    GET /recompute-crops/status/{job_id} and /recompute-crops/logs/{job_id}.
+    """
+    from src.app.sync_queue import enqueue_recompute_crops
+
+    project_name: str | None = None
+    try:
+        import tator
+
+        api = tator.get_api(_resolve_api_url(api_url), token)
+        proj = api.get_project(project_id)
+        project_name = getattr(proj, "name", None) or str(project_id)
+    except Exception as e:
+        logger.warning(f"recompute_crops get_project({project_id}) failed: {e}")
+    if not project_name or not str(project_name).strip():
+        project_name = str(project_id)
+
+    try:
+        job_id = enqueue_recompute_crops(
+            project_id=project_id,
+            version_id=version_id,
+            api_url=_resolve_api_url(api_url),
+            token=token,
+            port=port,
+            project_name=project_name.strip(),
+            force=force,
+            force_sync=force_sync,
+            vss_project_key=vss_project_key,
+            s3_bucket=s3_bucket,
+            s3_prefix=s3_prefix,
+        )
+        return {
+            "job_id": job_id,
+            "status": "queued",
+            "port": port,
+            "version_id": version_id,
+        }
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"Redis unavailable: {e}") from e
+
+
+@app_launch.get("/recompute-crops/status/{job_id}")
+async def recompute_crops_status(job_id: str) -> dict:
+    """Poll status of an enqueued crop-recompute job."""
+    from src.app.sync_queue import get_job_status
+
+    try:
+        return get_job_status(job_id)
+    except Exception as e:
+        raise HTTPException(
+            status_code=503, detail=f"Redis unavailable: {e}"
+        ) from e
+
+
+@app_launch.get("/recompute-crops/logs/{job_id}")
+async def recompute_crops_logs(job_id: str) -> dict:
+    """Return log lines from the crop-recompute worker job."""
+    from rq.exceptions import NoSuchJobError
+    from src.app.sync_queue import get_job_logs
+
+    try:
+        return get_job_logs(job_id)
+    except NoSuchJobError:
+        raise HTTPException(status_code=404, detail="Job not found") from None
+    except Exception as e:
+        raise HTTPException(
+            status_code=503, detail=f"Redis unavailable: {e}"
+        ) from e
+
+
 @app_launch.post("/sync-to-tator")
 async def sync_to_tator(
     project_id: int = Query(..., description="Tator project ID"),

--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -655,6 +655,89 @@ def _video_frame_group_fully_cached(
     return all(_crop_output_exists(out_path) for _, out_path in group)
 
 
+def _compute_square_coordinates(
+    loc: dict[str, Any], image_width: int, image_height: int
+) -> tuple[int, int, int, int] | None:
+    """
+    Compute in-frame square crop coordinates for a normalized localization box.
+
+    Pads the shorter side to make a square, then shifts/clamps to keep the crop
+    fully inside the frame to avoid out-of-frame black bars.
+    """
+    x = float(loc.get("x", 0))
+    y = float(loc.get("y", 0))
+    w = float(loc.get("width", 0))
+    h = float(loc.get("height", 0))
+    if w <= 0 or h <= 0 or image_width <= 0 or image_height <= 0:
+        return None
+
+    x1 = int(image_width * x)
+    y1 = int(image_height * y)
+    x2 = int(image_width * (x + w))
+    y2 = int(image_height * (y + h))
+
+    x1 = max(0, min(x1, image_width - 1))
+    y1 = max(0, min(y1, image_height - 1))
+    x2 = max(x1 + 1, min(x2, image_width))
+    y2 = max(y1 + 1, min(y2, image_height))
+
+    width = x2 - x1
+    height = y2 - y1
+    if width <= 0 or height <= 0:
+        return None
+
+    shorter_side = min(height, width)
+    longer_side = max(height, width)
+    delta = longer_side - shorter_side
+    pad_before = delta // 2
+    pad_after = delta - pad_before
+
+    if width < height:
+        x1 -= pad_before
+        x2 += pad_after
+    elif height < width:
+        y1 -= pad_before
+        y2 += pad_after
+
+    if y1 < 0:
+        shift = -y1
+        y1 = 0
+        y2 = min(image_height, y2 + shift)
+    if y2 > image_height:
+        shift = y2 - image_height
+        y2 = image_height
+        y1 = max(0, y1 - shift)
+
+    if x1 < 0:
+        shift = -x1
+        x1 = 0
+        x2 = min(image_width, x2 + shift)
+    if x2 > image_width:
+        shift = x2 - image_width
+        x2 = image_width
+        x1 = max(0, x1 - shift)
+
+    crop_w = x2 - x1
+    crop_h = y2 - y1
+    if crop_w <= 0 or crop_h <= 0:
+        return None
+
+    # If frame bounds prevented perfect padding, enforce in-frame square by
+    # shrinking the longer side to the shorter one around the crop center.
+    if crop_w != crop_h:
+        side = min(crop_w, crop_h)
+        cx = (x1 + x2) // 2
+        cy = (y1 + y2) // 2
+        x1 = max(0, min(cx - (side // 2), image_width - side))
+        y1 = max(0, min(cy - (side // 2), image_height - side))
+        x2 = x1 + side
+        y2 = y1 + side
+
+    if x2 <= x1 or y2 <= y1:
+        return None
+    return (x1, y1, x2, y2)
+
+
 def _crop_image_group(
     image_path: str | Path,
     locs_with_out_paths: list[tuple[dict, Path]],
@@ -675,21 +758,11 @@ def _crop_image_group(
             if _crop_output_exists(out_path):
                 total_ok += 1
                 continue
-            x = float(loc.get("x", 0))
-            y = float(loc.get("y", 0))
-            w = float(loc.get("width", 0))
-            h = float(loc.get("height", 0))
-            if w <= 0 or h <= 0:
+            square_coords = _compute_square_coordinates(loc, width, height)
+            if square_coords is None:
                 total_fail += 1
                 continue
-            x1 = int(width * x)
-            y1 = int(height * y)
-            x2 = int(width * (x + w))
-            y2 = int(height * (y + h))
-            x1 = max(0, min(x1, width - 1))
-            y1 = max(0, min(y1, height - 1))
-            x2 = max(1, min(x2, width))
-            y2 = max(1, min(y2, height))
+            x1, y1, x2, y2 = square_coords
 
             try:
                 out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -755,21 +828,11 @@ def _crop_media_group(
         total_ok = 0
         total_fail = 0
         for loc, out_path in locs_with_out_paths:
-            x = float(loc.get("x", 0))
-            y = float(loc.get("y", 0))
-            w = float(loc.get("width", 0))
-            h = float(loc.get("height", 0))
-            if w <= 0 or h <= 0:
+            square_coords = _compute_square_coordinates(loc, width, height)
+            if square_coords is None:
                 total_fail += 1
                 continue
-            x1 = int(width * x)
-            y1 = int(height * y)
-            x2 = int(width * (x + w))
-            y2 = int(height * (y + h))
-            x1 = max(0, min(x1, width - 1))
-            y1 = max(0, min(y1, height - 1))
-            x2 = max(1, min(x2, width))
-            y2 = max(1, min(y2, height))
+            x1, y1, x2, y2 = square_coords
 
             try:
                 out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -2403,7 +2466,14 @@ def _fetch_localizations_by_elemental_ids(
         return out
     effective_chunk = chunk_size if chunk_size is not None else _sync_to_tator_fetch_chunk()
     unique = list(dict.fromkeys(elemental_ids))
-    for chunk in _chunk_list(unique, effective_chunk):
+    total_chunks = max(1, (len(unique) + effective_chunk - 1) // effective_chunk)
+    logger.info(
+        "sync_edits_to_tator: fetch_localizations chunks=%s chunk_size=%s unique_ids=%s",
+        total_chunks,
+        effective_chunk,
+        len(unique),
+    )
+    for i, chunk in enumerate(_chunk_list(unique, effective_chunk), start=1):
         locs = api.get_localization_list_by_id(
             project_id,
             localization_id_query={"elemental_ids": chunk},
@@ -2415,6 +2485,13 @@ def _fetch_localizations_by_elemental_ids(
             if eid is None:
                 continue
             out[str(eid)] = loc
+        logger.info(
+            "sync_edits_to_tator: fetch_localizations chunk %s/%s size=%s resolved_total=%s",
+            i,
+            total_chunks,
+            len(chunk),
+            len(out),
+        )
     return out
 
 
@@ -2469,7 +2546,7 @@ def _bulk_patch_localizations_by_elemental_id(
     )
 
     sent_chunks = 0
-    for (_tid, key), eids in groups.items():
+    for group_idx, ((_tid, key), eids) in enumerate(groups.items(), start=1):
         attrs = dict(key)
         chunks = list(_chunk_list(eids, effective_chunk))
         for i, chunk in enumerate(chunks):
@@ -2483,6 +2560,16 @@ def _bulk_patch_localizations_by_elemental_id(
                 version=[version_id],
             )
             sent_chunks += 1
+            logger.info(
+                "sync_edits_to_tator: bulk PATCH chunk %s/%s "
+                "(group %s/%s, type=%s, size=%s)",
+                sent_chunks,
+                total_chunks,
+                group_idx,
+                len(groups),
+                _tid,
+                len(chunk),
+            )
             if effective_delay > 0 and (i + 1) < len(chunks):
                 time.sleep(effective_delay)
 
@@ -2636,7 +2723,17 @@ def _do_sync_edits_to_tator(
     force_sync: bool,
 ) -> dict[str, Any]:
     """Inner push routine; the public wrapper handles DB selection and locking."""
+    logger.info(f"sync_edits_to_tator: loading dataset {ds_name!r}")
     dataset = fo.load_dataset(ds_name)
+    try:
+        total_samples = len(dataset)
+    except Exception:  # pragma: no cover - len() shouldn't fail for normal datasets
+        total_samples = -1
+    logger.info(
+        f"sync_edits_to_tator: dataset {ds_name!r} loaded; "
+        f"scanning {total_samples if total_samples >= 0 else '?'} samples "
+        f"(force_sync={force_sync})"
+    )
 
     updated = 0
     failed = 0
@@ -2649,8 +2746,20 @@ def _do_sync_edits_to_tator(
     )
 
     pending: list[tuple[Any, str, dict[str, Any], Any]] = []
+    scan_progress_every = _env_int("FIFTYONE_SYNC_TO_TATOR_SCAN_LOG_EVERY", 5000)
+    scanned = 0
 
     for sample in dataset.iter_samples(autosave=False):
+        scanned += 1
+        if scan_progress_every > 0 and scanned % scan_progress_every == 0:
+            logger.info(
+                "sync_edits_to_tator: scan progress %s/%s pending=%s skipped=%s failed=%s",
+                scanned,
+                total_samples if total_samples >= 0 else "?",
+                len(pending),
+                skipped,
+                failed,
+            )
         elemental_id = sample["elemental_id"] if "elemental_id" in sample else None
         if not elemental_id:
             failed += 1
@@ -2697,12 +2806,24 @@ def _do_sync_edits_to_tator(
 
         pending.append((sample, eid_str, attrs, last_modified_at))
 
+    logger.info(
+        "sync_edits_to_tator: scan complete scanned=%s pending=%s skipped=%s failed=%s",
+        scanned,
+        len(pending),
+        skipped,
+        failed,
+    )
+
     if pending:
         updates: dict[str, dict[str, Any]] = {}
         for _sample, eid_str, attrs, _lm in pending:
             updates[eid_str] = attrs
 
         try:
+            logger.info(
+                "sync_edits_to_tator: resolving %s elemental_ids -> localizations",
+                len(updates),
+            )
             loc_by_eid = _fetch_localizations_by_elemental_ids(
                 api, project_id, version_id, list(updates.keys())
             )
@@ -2720,6 +2841,10 @@ def _do_sync_edits_to_tator(
             failed += len(pending)
             errors.append(f"Batch update to Tator failed: {e}")
         else:
+            logger.info(
+                "sync_edits_to_tator: writing tator_modified_at to %s samples",
+                len(pending),
+            )
             for sample, _eid_str, _attrs, last_modified_at in pending:
                 try:
                     sample[TATOR_MODIFIED_AT_FIELD] = last_modified_at

--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -1725,6 +1725,287 @@ def _cleanup_deleted_crops(
     return removed
 
 
+def _resolve_localizations_jsonl(
+    api: Any,
+    *,
+    project_id: int,
+    version_id: int | None,
+    api_url: str,
+    token: str,
+    force_sync: bool,
+    media_id_batch_size: int,
+    localization_batch_size: int,
+) -> tuple[str, list[int], bool]:
+    """
+    Resolve localizations JSONL and media ids for crop work.
+
+    Returns (localizations_path, media_ids_list, use_cached_jsonl).
+    """
+    jsonl_path = _localizations_jsonl_path(project_id, version_id)
+    localizations_path = ""
+    media_ids_list: list[int] = []
+    use_cached_jsonl = False
+    if not force_sync and _file_newer_than_days(jsonl_path, days=1.0):
+        line_count, media_ids_from_jsonl = _localizations_jsonl_line_count_and_media_ids(
+            jsonl_path
+        )
+        api_count = _get_localization_count_from_api(
+            api,
+            project_id,
+            version_id,
+            media_ids_from_jsonl or None,
+            media_id_batch_size,
+        )
+        if api_count is not None and line_count == api_count:
+            use_cached_jsonl = True
+            localizations_path = jsonl_path
+            media_ids_list = media_ids_from_jsonl
+            logger.info(
+                "Bypassing media and localization fetch: JSONL is newer than 1 day and "
+                "line count (%s) matches get_localization_count",
+                line_count,
+            )
+
+    if not use_cached_jsonl:
+        logger.info(
+            "Fetching media IDs... host=%s project_id=%s api_url=%s",
+            api_url.rstrip("/"),
+            project_id,
+            api_url,
+        )
+        media_ids_list = fetch_project_media_ids(
+            api_url, token, project_id, version_id=version_id
+        )
+        logger.info("Fetching localizations...")
+        localizations_path = fetch_and_save_localizations(
+            api,
+            project_id,
+            version_id=version_id,
+            media_ids=media_ids_list or None,
+            localization_batch_size=localization_batch_size,
+            media_id_batch_size=media_id_batch_size,
+        )
+    return (localizations_path, media_ids_list, use_cached_jsonl)
+
+
+def _load_localizations_list_and_manifest(
+    localizations_jsonl_path: str,
+) -> tuple[list[dict], dict[str, dict], set[int]]:
+    """Load JSONL localizations and build a fresh manifest map."""
+    localizations: list[dict] = []
+    updated_manifest: dict[str, dict] = {}
+    media_ids: set[int] = set()
+    with open(localizations_jsonl_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                loc = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            eid = loc.get("elemental_id") or loc.get("id")
+            media_id = loc.get("media")
+            if eid is None or media_id is None:
+                continue
+            eid = str(eid)
+            mid = int(media_id)
+            modified_at = loc.get("modified_datetime") or loc.get("created_datetime")
+            localizations.append(loc)
+            media_ids.add(mid)
+            updated_manifest[eid] = {
+                "modified_at": modified_at,
+                "media_id": mid,
+                "media_stem": str(mid),
+            }
+    return (localizations, updated_manifest, media_ids)
+
+
+def _delete_existing_crop_files(
+    locs_to_crop: list[dict], updated_manifest: dict[str, dict], crops_dir: str
+) -> int:
+    """Delete existing crop files for localizations to force overwrite."""
+    crops_path = Path(crops_dir)
+    removed = 0
+    for loc in locs_to_crop:
+        eid = loc.get("elemental_id") or loc.get("id")
+        if eid is None:
+            continue
+        entry = updated_manifest.get(str(eid)) or {}
+        media_stem = entry.get("media_stem")
+        if not media_stem:
+            media_id = loc.get("media")
+            if media_id is None:
+                continue
+            media_stem = str(int(media_id))
+        crop_file = crops_path / str(media_stem) / f"{eid}.png"
+        if crop_file.exists():
+            try:
+                crop_file.unlink()
+                removed += 1
+            except OSError:
+                pass
+    if removed:
+        logger.info("Force crop recompute removed %s existing crop file(s)", removed)
+    return removed
+
+
+def _run_crop_pipeline(
+    api: Any,
+    *,
+    project_id: int,
+    version_id: int | None,
+    api_url: str,
+    token: str,
+    force_sync: bool,
+    force: bool,
+    media_id_batch_size: int,
+    localization_batch_size: int,
+    s3_bucket: str | None = None,
+    s3_crops_prefix: str | None = None,
+) -> dict[str, Any]:
+    """
+    Run crop refresh pipeline and return counts/paths/context.
+
+    This function is shared by full sync and crop-recompute jobs.
+    """
+    dl_dir = _download_dir(project_id)
+    crops = _crops_dir(project_id, version_id)
+    localizations_path = ""
+    localizations_count = 0
+    cache_misses = 0
+    cache_hits = 0
+    removed_existing = 0
+    num_cropped = 0
+    num_failed = 0
+    used_cached_jsonl = False
+    try:
+        (
+            localizations_path,
+            media_ids_list,
+            used_cached_jsonl,
+        ) = _resolve_localizations_jsonl(
+            api,
+            project_id=project_id,
+            version_id=version_id,
+            api_url=api_url,
+            token=token,
+            force_sync=force_sync,
+            media_id_batch_size=media_id_batch_size,
+            localization_batch_size=localization_batch_size,
+        )
+        if localizations_path:
+            logger.info("saved_localizations_path (JSONL): %s", localizations_path)
+        old_manifest = _load_crop_manifest(project_id, version_id)
+        if force:
+            (
+                all_locs,
+                updated_manifest,
+                media_ids_needed,
+            ) = _load_localizations_list_and_manifest(localizations_path)
+            locs_to_crop = all_locs
+            _cleanup_deleted_crops(old_manifest, updated_manifest, crops)
+            removed_existing = _delete_existing_crop_files(
+                locs_to_crop, updated_manifest, crops
+            )
+            logger.info(
+                "Force crop recompute enabled — scheduling all %s localizations",
+                len(locs_to_crop),
+            )
+        else:
+            media_ids_needed, locs_to_crop, updated_manifest = _find_crop_cache_misses(
+                localizations_jsonl_path=localizations_path,
+                crops_dir=crops,
+                manifest=old_manifest,
+                download_dir=dl_dir,
+            )
+            _cleanup_deleted_crops(old_manifest, updated_manifest, crops)
+
+        localizations_count = len(updated_manifest)
+        cache_misses = len(locs_to_crop)
+        cache_hits = max(0, localizations_count - cache_misses)
+
+        all_media: list[Any] = []
+        if not media_ids_list:
+            logger.info("No media IDs for project %s; skipping download", project_id)
+        elif not media_ids_needed:
+            logger.info(
+                "All %s crops are cached; skipping media download", localizations_count
+            )
+        else:
+            needed_ids = [mid for mid in media_ids_list if mid in media_ids_needed]
+            logger.info(
+                "Getting %s/%s media objects for cropping...",
+                len(needed_ids),
+                len(media_ids_list),
+            )
+            all_media = get_media_chunked(
+                api, project_id, needed_ids, media_id_batch_size=media_id_batch_size
+            )
+            if not all_media:
+                logger.info(
+                    "No Media objects returned for %s ids; skipping download",
+                    len(needed_ids),
+                )
+            else:
+                logger.info(
+                    "Saving %s media files to tmp (images + videos)...", len(all_media)
+                )
+                dl_dir = save_media_to_tmp(
+                    api, project_id, all_media, media_ids_filter=media_ids_needed
+                )
+
+        if locs_to_crop and localizations_path:
+            num_cropped, num_failed = crop_localizations_parallel(
+                dl_dir,
+                localizations_path,
+                crops,
+                size=224,
+                locs_to_crop=locs_to_crop,
+                media_objects=all_media,
+            )
+            _cleanup_downloaded_videos(dl_dir)
+        elif not locs_to_crop:
+            logger.info("No crop cache misses; skipping crop step")
+
+        _patch_manifest_stems(updated_manifest, dl_dir, media_objects=all_media)
+        _save_crop_manifest(project_id, version_id, updated_manifest)
+
+        if s3_bucket and os.path.isdir(crops):
+            _sync_local_dir_with_s3(crops, s3_bucket, s3_crops_prefix)
+
+        _cleanup_download_dir(project_id)
+        return {
+            "status": "ok",
+            "saved_media_dir": dl_dir or None,
+            "saved_localizations_path": localizations_path or None,
+            "saved_crops_dir": crops or None,
+            "localizations_count": localizations_count,
+            "cache_hits": cache_hits,
+            "cache_misses": cache_misses,
+            "num_cropped": num_cropped,
+            "num_failed": num_failed,
+            "removed_existing": removed_existing,
+            "used_cached_jsonl": used_cached_jsonl,
+        }
+    except Exception as e:
+        logger.error(f"Crop pipeline failed: {e}")
+        return {
+            "status": "error",
+            "message": str(e),
+            "saved_media_dir": dl_dir or None,
+            "saved_localizations_path": localizations_path or None,
+            "saved_crops_dir": crops or None,
+            "localizations_count": localizations_count,
+            "cache_hits": cache_hits,
+            "cache_misses": cache_misses,
+            "num_cropped": num_cropped,
+            "num_failed": num_failed,
+            "removed_existing": removed_existing,
+            "used_cached_jsonl": used_cached_jsonl,
+        }
+
+
 def _tator_localization_url(
     api_url: str,
     project_id: int,
@@ -2927,6 +3208,159 @@ def run_sync_job(
                 pass
 
 
+def recompute_crops_for_version(
+    project_id: int,
+    version_id: int,
+    api_url: str,
+    token: str,
+    port: int,
+    project_name: str | None = None,
+    force: bool = False,
+    force_sync: bool = False,
+    vss_project_key: str | None = None,
+    s3_bucket: str | None = None,
+    s3_prefix: str | None = None,
+    database_name: str | None = None,
+) -> dict[str, Any]:
+    """
+    Recompute crops for a project/version without building the dataset.
+
+    Uses the same crop pipeline as full sync; force=True recomputes all crops by
+    bypassing cache-hit checks and deleting existing crop files before recropping.
+    """
+    if not (s3_bucket and s3_bucket.strip()):
+        s3_cfg = get_s3_config(
+            project_id, project_name=project_name, vss_project_key=vss_project_key
+        )
+        if s3_cfg:
+            s3_bucket = s3_cfg.get("s3_bucket") or None
+            s3_prefix = s3_cfg.get("s3_prefix") or s3_prefix
+    if s3_bucket:
+        s3_bucket = s3_bucket.strip()
+        s3_prefix = (s3_prefix or "").strip() or None
+    s3_crops_prefix = (
+        _s3_crops_prefix(s3_prefix, project_id, version_id) if s3_bucket else None
+    )
+    resolved_db = (
+        database_name.strip() if database_name and database_name.strip() else None
+    ) or get_database_name(project_id, port, project_name=project_name)
+    lock_key = get_sync_lock_key(resolved_db, project_id, version_id)
+    logger.info(
+        "Acquiring crop-recompute lock: key=%s project_id=%s version_id=%s force=%s force_sync=%s",
+        lock_key,
+        project_id,
+        version_id,
+        force,
+        force_sync,
+    )
+    if not try_acquire_sync_lock(lock_key):
+        return {
+            "status": "busy",
+            "message": "This dataset is being updated by another sync. Please try again in a few minutes.",
+            "database_name": resolved_db,
+        }
+
+    config_path = os.getenv("FIFTYONE_SYNC_CONFIG_PATH")
+    config: dict[str, Any] = {}
+    if config_path and os.path.exists(config_path):
+        try:
+            config = _load_config(config_path)
+        except Exception as e:
+            logger.info(f"Failed to load config {config_path}: {e}")
+    media_id_batch_size = (
+        config.get("media_id_batch_size") or _DEFAULT_MEDIA_ID_BATCH_SIZE
+    )
+    localization_batch_size = (
+        config.get("localization_batch_size") or _DEFAULT_LOCALIZATION_BATCH_SIZE
+    )
+
+    try:
+        api = tator.get_api(api_url.rstrip("/"), token)
+        crop_result = _run_crop_pipeline(
+            api,
+            project_id=project_id,
+            version_id=version_id,
+            api_url=api_url,
+            token=token,
+            force_sync=force_sync,
+            force=force,
+            media_id_batch_size=media_id_batch_size,
+            localization_batch_size=localization_batch_size,
+            s3_bucket=s3_bucket,
+            s3_crops_prefix=s3_crops_prefix,
+        )
+        crop_result["database_name"] = resolved_db
+        crop_result["force"] = force
+        crop_result["force_sync"] = force_sync
+        crop_result["port"] = port
+        return crop_result
+    finally:
+        logger.info(f"Releasing crop-recompute lock: key={lock_key}")
+        release_sync_lock(lock_key)
+
+
+def run_recompute_crops_job(
+    project_id: int,
+    version_id: int,
+    api_url: str,
+    token: str,
+    port: int,
+    project_name: str,
+    force: bool = False,
+    force_sync: bool = False,
+    vss_project_key: str | None = None,
+    s3_bucket: str | None = None,
+    s3_prefix: str | None = None,
+    database_name: str | None = None,
+) -> dict[str, Any]:
+    """RQ entrypoint for queued crop recompute jobs."""
+    from src.app.database_manager import register_project_id_name
+
+    logger.info(
+        "run_recompute_crops_job received project_id=%s version_id=%s port=%s force=%s force_sync=%s",
+        project_id,
+        version_id,
+        port,
+        force,
+        force_sync,
+    )
+    job_meta_handler: logging.Handler | None = None
+    try:
+        from rq import get_current_job
+
+        job = get_current_job()
+        if job is not None:
+            job_meta_handler = _JobMetaLogHandler(job)
+            job_meta_handler.setLevel(logging.DEBUG)
+            logger.addHandler(job_meta_handler)
+    except Exception:  # rq not installed or no worker context
+        pass
+
+    try:
+        register_project_id_name(project_id, project_name)
+        return recompute_crops_for_version(
+            project_id=project_id,
+            version_id=version_id,
+            api_url=api_url,
+            token=token,
+            port=port,
+            project_name=project_name,
+            force=force,
+            force_sync=force_sync,
+            vss_project_key=vss_project_key,
+            s3_bucket=s3_bucket,
+            s3_prefix=s3_prefix,
+            database_name=database_name,
+        )
+    finally:
+        if job_meta_handler is not None:
+            try:
+                logger.removeHandler(job_meta_handler)
+                job_meta_handler.close()
+            except Exception:
+                pass
+
+
 def run_sync_to_tator_job(
     project_id: int,
     version_id: int,
@@ -3149,125 +3583,47 @@ def sync_project_to_fiftyone(
     )
 
     try:
-        dl_dir = _download_dir(project_id)
+        dl_dir = ""
         localizations_path = ""
         crops = _crops_dir(project_id, version_id)
+        use_cached_jsonl = False
         try:
             host = api_url.rstrip("/")
             api = tator.get_api(host, token)
-
-            # Bypass: skip expensive media + localization fetch when JSONL is fresh and count matches (unless force_sync)
-            jsonl_path = _localizations_jsonl_path(project_id, version_id)
-            use_cached_jsonl = False
-            if not force_sync and _file_newer_than_days(jsonl_path, days=1.0):
-                line_count, media_ids_from_jsonl = (
-                    _localizations_jsonl_line_count_and_media_ids(jsonl_path)
-                )
-                api_count = _get_localization_count_from_api(
-                    api,
-                    project_id,
-                    version_id,
-                    media_ids_from_jsonl or None,
-                    media_id_batch_size,
-                )
-                if api_count is not None and line_count == api_count:
-                    use_cached_jsonl = True
-                    localizations_path = jsonl_path
-                    media_ids_list = media_ids_from_jsonl
-                    logger.info(
-                        f"Bypassing media and localization fetch: JSONL is newer than 1 day and "
-                        f"line count ({line_count}) matches get_localization_count"
-                    )
-
-            if not use_cached_jsonl:
-                # 1. Fetch media IDs (lightweight metadata, needed for localization query)
-                logger.info(
-                    f"Fetching media IDs... host={host} project_id={project_id} api_url={api_url}"
-                )
-                media_ids_list = fetch_project_media_ids(
-                    api_url, token, project_id, version_id=version_id
-                )
-
-                # 2. Fetch localizations first (cheap metadata)
-                logger.info("Fetching localizations...")
-                localizations_path = fetch_and_save_localizations(
-                    api,
-                    project_id,
-                    version_id=version_id,
-                    media_ids=media_ids_list or None,
-                    localization_batch_size=localization_batch_size,
-                    media_id_batch_size=media_id_batch_size,
-                )
-
-            if localizations_path:
-                logger.info(f"saved_localizations_path (JSONL): {localizations_path}")
-
-            # 3. Determine which crops are missing or stale (cache miss)
-            old_manifest = _load_crop_manifest(project_id, version_id)
-            media_ids_needed, locs_to_crop, updated_manifest = _find_crop_cache_misses(
-                localizations_jsonl_path=localizations_path,
-                crops_dir=crops,
-                manifest=old_manifest,
-                download_dir=dl_dir,
+            crop_result = _run_crop_pipeline(
+                api,
+                project_id=project_id,
+                version_id=version_id,
+                api_url=api_url,
+                token=token,
+                force_sync=force_sync,
+                force=False,
+                media_id_batch_size=media_id_batch_size,
+                localization_batch_size=localization_batch_size,
+                s3_bucket=s3_bucket,
+                s3_crops_prefix=s3_crops_prefix,
             )
-
-            # 4. Clean up orphaned crop files for deleted localizations
-            _cleanup_deleted_crops(old_manifest, updated_manifest, crops)
-
-            # 5. Download only media that have cache misses; get Media objects for cropping
-            all_media: list[Any] = []
-            if not media_ids_list:
-                logger.info(f"No media IDs for project {project_id}; skipping download")
-            elif not media_ids_needed:
-                logger.info(
-                    f"All {len(updated_manifest)} crops are cached; skipping media download"
-                )
-            else:
-                needed_ids = [mid for mid in media_ids_list if mid in media_ids_needed]
-                logger.info(
-                    f"Getting {len(needed_ids)}/{len(media_ids_list)} media objects (cache misses)..."
-                )
-                all_media = get_media_chunked(
-                    api, project_id, needed_ids, media_id_batch_size=media_id_batch_size
-                )
-                if not all_media:
-                    logger.info(
-                        f"No Media objects returned for {len(needed_ids)} ids; skipping download"
-                    )
-                else:
-                    logger.info(
-                        f"Saving {len(all_media)} media files to tmp (images + videos)..."
-                    )
-                    dl_dir = save_media_to_tmp(
-                        api, project_id, all_media, media_ids_filter=media_ids_needed
-                    )
-
-            # 6. Crop only the cache-miss localizations (ffmpeg; image + video)
-            if locs_to_crop and localizations_path:
-                crop_localizations_parallel(
-                    dl_dir,
-                    localizations_path,
-                    crops,
-                    size=224,
-                    locs_to_crop=locs_to_crop,
-                    media_objects=all_media,
-                )
-                _cleanup_downloaded_videos(dl_dir)
-            elif not locs_to_crop:
-                logger.info("No crop cache misses; skipping crop step")
-
-            # 7. Patch manifest stems from downloaded filenames and from Media (video)
-            _patch_manifest_stems(updated_manifest, dl_dir, media_objects=all_media)
-
-            # 8. Persist the updated manifest
-            _save_crop_manifest(project_id, version_id, updated_manifest)
-
-            # 9. Optional: two-way sync crop images with S3 (prefix = e.g. fiftyone/raw/12/v21/crops)
-            if s3_bucket and os.path.isdir(crops):
-                _sync_local_dir_with_s3(crops, s3_bucket, s3_crops_prefix)
-
-            # 10. Remove downloaded media to reclaim disk space
-            _cleanup_download_dir(project_id)
+            if crop_result.get("status") != "ok":
+                return {
+                    "status": "error",
+                    "message": crop_result.get("message") or "Crop pipeline failed",
+                    "database_name": resolved_db,
+                    "saved_media_dir": crop_result.get("saved_media_dir"),
+                    "saved_localizations_path": crop_result.get(
+                        "saved_localizations_path"
+                    ),
+                    "saved_crops_dir": crop_result.get("saved_crops_dir"),
+                }
+            dl_dir = str(crop_result.get("saved_media_dir") or "")
+            localizations_path = str(crop_result.get("saved_localizations_path") or "")
+            use_cached_jsonl = bool(crop_result.get("used_cached_jsonl"))
+            logger.info(
+                "Crop pipeline complete: cropped=%s failed=%s misses=%s hits=%s",
+                crop_result.get("num_cropped"),
+                crop_result.get("num_failed"),
+                crop_result.get("cache_misses"),
+                crop_result.get("cache_hits"),
+            )
 
         except Exception as e:
             logger.error(f"Sync failed: {e}")

--- a/src/app/sync_queue.py
+++ b/src/app/sync_queue.py
@@ -172,6 +172,46 @@ def enqueue_dimreduce(
     return job.id
 
 
+def enqueue_recompute_crops(
+    project_id: int,
+    version_id: int,
+    api_url: str,
+    token: str,
+    port: int,
+    project_name: str,
+    force: bool = False,
+    force_sync: bool = False,
+    vss_project_key: str | None = None,
+    s3_bucket: str | None = None,
+    s3_prefix: str | None = None,
+    database_name: str | None = None,
+) -> str:
+    """Enqueue a crop-recompute job and return RQ job id."""
+    from rq import Queue
+
+    conn = get_connection()
+    queue = Queue(QUEUE_NAME, connection=conn)
+    job = queue.enqueue(
+        "src.app.sync.run_recompute_crops_job",
+        project_id=project_id,
+        version_id=version_id,
+        api_url=api_url,
+        token=token,
+        port=port,
+        project_name=project_name,
+        force=force,
+        force_sync=force_sync,
+        vss_project_key=vss_project_key,
+        s3_bucket=s3_bucket,
+        s3_prefix=s3_prefix,
+        database_name=database_name,
+        job_timeout=3600 * 24,  # 24h for large recrop jobs
+        result_ttl=3600 * 24,
+        failure_ttl=3600,
+    )
+    return job.id
+
+
 def get_job_status(job_id: str) -> dict[str, Any]:
     """
     Return status and result for a sync job.

--- a/tests/test_recompute_crops.py
+++ b/tests/test_recompute_crops.py
@@ -1,0 +1,244 @@
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+def _write_config(tmp_path):
+    config_path = tmp_path / "sync-config.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "projects:",
+                "  DemoProject:",
+                "    databases:",
+                "      - uri: mongodb://localhost:27017/demo",
+                "        port: 5151",
+            ]
+        )
+    )
+    return config_path
+
+
+def _load_main_module(monkeypatch, tmp_path):
+    config_path = _write_config(tmp_path)
+    monkeypatch.setenv("FIFTYONE_SYNC_CONFIG_PATH", str(config_path))
+    try:
+        if "src.app.main" in sys.modules:
+            main_module = sys.modules["src.app.main"]
+        else:
+            import src.app.main as main_module
+    except Exception as exc:
+        pytest.skip(f"FastAPI app import unavailable in this env: {exc}")
+    return main_module
+
+
+def test_recompute_crops_endpoint_enqueue(monkeypatch, tmp_path):
+    main_module = _load_main_module(monkeypatch, tmp_path)
+
+    fake_api = SimpleNamespace(get_project=lambda _pid: SimpleNamespace(name="DemoProject"))
+    fake_tator = SimpleNamespace(get_api=lambda _url, _token: fake_api)
+    monkeypatch.setitem(sys.modules, "tator", fake_tator)
+
+    from src.app import sync_queue
+
+    captured = {}
+
+    def _fake_enqueue(**kwargs):
+        captured.update(kwargs)
+        return "job-123"
+
+    monkeypatch.setattr(sync_queue, "enqueue_recompute_crops", _fake_enqueue)
+
+    from fastapi.testclient import TestClient
+
+    client = TestClient(main_module.app)
+    response = client.post(
+        "/recompute-crops",
+        params={
+            "project_id": 1,
+            "version_id": 42,
+            "api_url": "http://localhost:8080",
+            "token": "abc",
+            "port": 5151,
+            "force": "true",
+            "force_sync": "true",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "job_id": "job-123",
+        "status": "queued",
+        "port": 5151,
+        "version_id": 42,
+    }
+    assert captured["project_name"] == "DemoProject"
+    assert captured["force"] is True
+    assert captured["force_sync"] is True
+
+
+def test_recompute_crops_status_and_logs_routes(monkeypatch, tmp_path):
+    main_module = _load_main_module(monkeypatch, tmp_path)
+
+    from src.app import sync_queue
+
+    monkeypatch.setattr(
+        sync_queue, "get_job_status", lambda _job_id: {"status": "finished"}
+    )
+    monkeypatch.setattr(
+        sync_queue, "get_job_logs", lambda _job_id: {"log_lines": ["line-a"]}
+    )
+
+    from fastapi.testclient import TestClient
+
+    client = TestClient(main_module.app)
+    status_resp = client.get("/recompute-crops/status/job-123")
+    logs_resp = client.get("/recompute-crops/logs/job-123")
+    assert status_resp.status_code == 200
+    assert status_resp.json() == {"status": "finished"}
+    assert logs_resp.status_code == 200
+    assert logs_resp.json() == {"log_lines": ["line-a"]}
+
+
+def test_run_crop_pipeline_miss_only(monkeypatch, tmp_path):
+    import src.app.sync as sync
+
+    localizations = tmp_path / "localizations.jsonl"
+    localizations.write_text("{}\n")
+    download_dir = tmp_path / "downloads"
+    download_dir.mkdir()
+    crops_dir = tmp_path / "crops"
+    crops_dir.mkdir()
+
+    loc = {"elemental_id": "eid-1", "media": 1}
+    updated_manifest = {
+        "eid-1": {"modified_at": "t1", "media_id": 1, "media_stem": "1_img"},
+        "eid-2": {"modified_at": "t2", "media_id": 2, "media_stem": "2_img"},
+    }
+
+    monkeypatch.setattr(
+        sync,
+        "_resolve_localizations_jsonl",
+        lambda *args, **kwargs: (str(localizations), [1, 2], False),
+    )
+    monkeypatch.setattr(sync, "_download_dir", lambda _pid: str(download_dir))
+    monkeypatch.setattr(sync, "_crops_dir", lambda _pid, _vid: str(crops_dir))
+    monkeypatch.setattr(sync, "_load_crop_manifest", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(sync, "_cleanup_deleted_crops", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(
+        sync,
+        "_find_crop_cache_misses",
+        lambda **kwargs: ({1}, [loc], updated_manifest),
+    )
+    monkeypatch.setattr(sync, "get_media_chunked", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        sync, "_patch_manifest_stems", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(sync, "_save_crop_manifest", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(sync, "_cleanup_download_dir", lambda *_args, **_kwargs: None)
+
+    captured = {}
+
+    def _fake_crop(*args, **kwargs):
+        captured["locs_to_crop"] = kwargs.get("locs_to_crop")
+        return (1, 0)
+
+    monkeypatch.setattr(sync, "crop_localizations_parallel", _fake_crop)
+    monkeypatch.setattr(sync, "_cleanup_downloaded_videos", lambda *_args: None)
+
+    out = sync._run_crop_pipeline(
+        object(),
+        project_id=1,
+        version_id=42,
+        api_url="http://localhost:8080",
+        token="abc",
+        force_sync=False,
+        force=False,
+        media_id_batch_size=10,
+        localization_batch_size=10,
+        s3_bucket=None,
+        s3_crops_prefix=None,
+    )
+    assert out["status"] == "ok"
+    assert out["cache_misses"] == 1
+    assert out["cache_hits"] == 1
+    assert out["num_cropped"] == 1
+    assert out["removed_existing"] == 0
+    assert captured["locs_to_crop"] == [loc]
+
+
+def test_run_crop_pipeline_force_all(monkeypatch, tmp_path):
+    import src.app.sync as sync
+
+    localizations = tmp_path / "localizations.jsonl"
+    localizations.write_text("{}\n")
+    download_dir = tmp_path / "downloads"
+    download_dir.mkdir()
+    crops_dir = tmp_path / "crops"
+    crops_dir.mkdir()
+
+    locs = [
+        {"elemental_id": "eid-1", "media": 1},
+        {"elemental_id": "eid-2", "media": 1},
+    ]
+    updated_manifest = {
+        "eid-1": {"modified_at": "t1", "media_id": 1, "media_stem": "1_img"},
+        "eid-2": {"modified_at": "t2", "media_id": 1, "media_stem": "1_img"},
+    }
+
+    monkeypatch.setattr(
+        sync,
+        "_resolve_localizations_jsonl",
+        lambda *args, **kwargs: (str(localizations), [1], True),
+    )
+    monkeypatch.setattr(sync, "_download_dir", lambda _pid: str(download_dir))
+    monkeypatch.setattr(sync, "_crops_dir", lambda _pid, _vid: str(crops_dir))
+    monkeypatch.setattr(
+        sync, "_load_crop_manifest", lambda *_args, **_kwargs: {"old": {}}
+    )
+    monkeypatch.setattr(sync, "_cleanup_deleted_crops", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(
+        sync,
+        "_load_localizations_list_and_manifest",
+        lambda _path: (locs, updated_manifest, {1}),
+    )
+    monkeypatch.setattr(sync, "get_media_chunked", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        sync, "_patch_manifest_stems", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(sync, "_save_crop_manifest", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(sync, "_cleanup_download_dir", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        sync, "_delete_existing_crop_files", lambda *_args, **_kwargs: 2
+    )
+    monkeypatch.setattr(sync, "_cleanup_downloaded_videos", lambda *_args: None)
+
+    captured = {}
+
+    def _fake_crop(*args, **kwargs):
+        captured["locs_to_crop"] = kwargs.get("locs_to_crop")
+        return (2, 0)
+
+    monkeypatch.setattr(sync, "crop_localizations_parallel", _fake_crop)
+
+    out = sync._run_crop_pipeline(
+        object(),
+        project_id=1,
+        version_id=42,
+        api_url="http://localhost:8080",
+        token="abc",
+        force_sync=False,
+        force=True,
+        media_id_batch_size=10,
+        localization_batch_size=10,
+        s3_bucket=None,
+        s3_crops_prefix=None,
+    )
+    assert out["status"] == "ok"
+    assert out["cache_misses"] == 2
+    assert out["cache_hits"] == 0
+    assert out["num_cropped"] == 2
+    assert out["removed_existing"] == 2
+    assert captured["locs_to_crop"] == locs
+


### PR DESCRIPTION
## Summary
- add an RQ-backed queued pipeline for crop recomputation and sync pushes to improve throughput and reduce contention
- update sync behavior to use square in-frame crop coordinates and include supporting sync lock/queue utilities
- expand docs/changelog and add recompute crop tests covering the new flow