### PR TITLE
feat(launcher): remove Recompute Dimreduce button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,3 +80,9 @@ Run tests from the repo root after substantive changes (see `README.md` / projec
 ## Graphify
 
 Before answering architecture or “how does X connect to Y?” questions, read `graphify-out/GRAPH_REPORT.md`. After editing code in a session, run `graphify update .` (AST-only, no API cost).
+
+---
+
+## Tools
+
+- **gh (GitHub CLI):** `/opt/homebrew/bin/gh`

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ embeddings:
   project_name: null                  # optional; override for embed service URL path (default: project_id)
 ```
 
-To recompute dimensionality reduction without re-embedding, use the launcher `Recompute Dimreduce` button (or `POST /dimreduce`). UMAP is stored under `${brain_key}_umap`; PCA and t-SNE are stored under `${brain_key}_pca` and `${brain_key}_tsne`.
+To recompute dimensionality reduction without re-embedding, use `POST /dimreduce`. UMAP is stored under `${brain_key}_umap`; PCA and t-SNE are stored under `${brain_key}_pca` and `${brain_key}_tsne`.
 
 **Requirements:** The embed service must be running (e.g. Fast-VSS at the URL above). Set `FASTVSS_API_URL` to override the base URL. For UMAP visualization, install `umap-learn` in the sync service venv:
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ This service exposes a Jinja2 template for [Tator Hosted Templates](https://www.
      - `base_port`: `5151`
      - `iframe_host`: host for the FiftyOne app URL (same host you use for Tator; not `host.docker.internal`).
      - `message`, `config_yaml`: optional header text / YAML exposed as `window.FIFTYONE_CONFIG_YAML`.
-     - **Sync**: set `sync_service_url` and `api_url` (no token tparam). User enters token in applet and clicks **Verify Token**; optional `version_id` to preselect.
+     - **Sync**: set `sync_service_url` and `api_url` (no token tparam). User enters token in applet and clicks **Verify Token**; optional `version_id`, `section_id`, and `query` (Tator `encoded_search`) tparams to preselect filters.
 
 Click **Save**.
 
@@ -274,6 +274,8 @@ Optional query param **`database_name`** on `GET /launch` and `POST /sync` overr
 | `api_url` | yes | Tator REST API base URL |
 | `token` | yes | Tator API token |
 | `version_id` | no | Version ID filter for localizations |
+| `section_id` | no | Tator media section ID; ANDed with `query` when both set |
+| `query` | no | Tator `encoded_search` filter (base64 Object_Search); ANDed with `section_id` when both set |
 | `database_name` | no | Override MongoDB database name |
 | `config_path` | no | Path to YAML/JSON config file for dataset build |
 | `launch_app` | no | Launch FiftyOne app after sync (default: true) |

--- a/src/app/launcher_template.py
+++ b/src/app/launcher_template.py
@@ -91,6 +91,16 @@ LAUNCHER_TEMPLATE = r"""
           </td>
         </tr>
         <tr>
+          <th>Section</th>
+          <td>
+            <div class="cell-controls">
+              <select id="section-select" aria-label="section" disabled title="Optional media section filter (ANDed with query when both set).">
+                <option value="">All sections</option>
+              </select>
+            </div>
+          </td>
+        </tr>
+        <tr>
           <th>Voxel Dataset</th>
           <td>
             <div class="cell-controls">
@@ -160,10 +170,13 @@ LAUNCHER_TEMPLATE = r"""
       if (configYaml) window.FIFTYONE_CONFIG_YAML = configYaml;
       var apiUrl = "{{ api_url | default('') | e }}";
       var initialVersionId = "{{ version_id | default('') | e }}";
+      var initialSectionId = "{{ section_id | default('') | e }}";
+      var syncQuery = "{{ query | default('') | e }}";
       var syncBtn = document.getElementById('sync-from-tator-btn');
       var syncStatus = document.getElementById('sync-status');
       var fiftyoneAppLink = document.getElementById('fiftyone-app-link');
       var versionSelect = document.getElementById('version-select');
+      var sectionSelect = document.getElementById('section-select');
       var voxelDatasetSelect = document.getElementById('voxel-dataset-select');
       var vssProjectSelect = document.getElementById('vss-project-select');
       var vssProjectRow = document.getElementById('vss-project-row');
@@ -290,6 +303,7 @@ LAUNCHER_TEMPLATE = r"""
       function setSyncControlsEnabled(enabled) {
         tokenVerified = enabled;
         if (versionSelect) versionSelect.disabled = !enabled;
+        if (sectionSelect) sectionSelect.disabled = !enabled;
         if (vssProjectSelect) vssProjectSelect.disabled = !enabled;
         updateSyncButtonsState();
       }
@@ -345,6 +359,41 @@ LAUNCHER_TEMPLATE = r"""
             vssProjectSelect.innerHTML = '<option value="">Failed to load VSS projects</option>';
           });
       }
+      function loadSections(token) {
+        if (!sectionSelect || !syncServiceUrl || !apiUrl || !token) return;
+        sectionSelect.innerHTML = '<option value="">Loading…</option>';
+        fetch(syncServiceUrl + '/sections?project_id=' + project + '&api_url=' + encodeURIComponent(apiUrl), {
+          headers: { 'Authorization': 'Token ' + token }
+        })
+          .then(function(r) {
+            if (!r.ok) return r.json().then(function(d) { throw new Error(d.detail || r.statusText); });
+            return r.json();
+          })
+          .then(function(sections) {
+            sectionSelect.innerHTML = '';
+            var allOpt = document.createElement('option');
+            allOpt.value = '';
+            allOpt.textContent = 'All sections';
+            sectionSelect.appendChild(allOpt);
+            (sections || []).forEach(function(s) {
+              var opt = document.createElement('option');
+              opt.value = String(s.id);
+              opt.textContent = s.name + (s.id != null ? ' (' + s.id + ')' : '');
+              sectionSelect.appendChild(opt);
+            });
+            if (initialSectionId && sectionSelect.querySelector('option[value="' + initialSectionId + '"]')) {
+              sectionSelect.value = initialSectionId;
+            }
+          })
+          .catch(function() {
+            sectionSelect.innerHTML = '';
+            var opt = document.createElement('option');
+            opt.value = '';
+            opt.textContent = 'All sections';
+            sectionSelect.appendChild(opt);
+            if (initialSectionId) sectionSelect.value = initialSectionId;
+          });
+      }
       function loadVersions(token) {
         if (!versionSelect || !syncServiceUrl || !apiUrl || !token) return;
         versionSelect.innerHTML = '<option value="">Loading…</option>';
@@ -391,6 +440,13 @@ LAUNCHER_TEMPLATE = r"""
             opt.value = '';
             opt.textContent = 'Enter token and click Test';
             versionSelect.appendChild(opt);
+          }
+          if (sectionSelect) {
+            sectionSelect.innerHTML = '';
+            var secOpt = document.createElement('option');
+            secOpt.value = '';
+            secOpt.textContent = 'Enter token and click Test';
+            sectionSelect.appendChild(secOpt);
           }
           if (vssProjectSelect && vssProjectRow) {
             vssProjectSelect.innerHTML = '<option value="">Enter token and click Test</option>';
@@ -468,6 +524,7 @@ LAUNCHER_TEMPLATE = r"""
             .then(function(versions) {
               setSyncControlsEnabled(true);
               loadVersions(token);
+              loadSections(token);
               loadVssProjects(token);
               syncStatus.textContent = 'Token OK. Resolving port/database…';
               updateDatabaseInfo(token);
@@ -583,6 +640,9 @@ LAUNCHER_TEMPLATE = r"""
           if (fiftyoneAppLink) fiftyoneAppLink.style.display = 'none';
           var params = new URLSearchParams({ project_id: String(project), api_url: apiUrl, token: token, launch_app: 'true', port: port });
           if (v) params.set('version_id', v);
+          var s = sectionSelect ? sectionSelect.value : '';
+          if (s) params.set('section_id', s);
+          if (syncQuery) params.set('query', syncQuery);
           if (vssProjectKey) params.set('vss_project_key', vssProjectKey);
           var forceSyncEl = document.getElementById('force-sync-checkbox');
           if (forceSyncEl && forceSyncEl.checked) {

--- a/src/app/launcher_template.py
+++ b/src/app/launcher_template.py
@@ -119,12 +119,6 @@ LAUNCHER_TEMPLATE = r"""
                 <input type="checkbox" id="force-sync-checkbox" name="force_sync" value="1"> Force sync
               </label>
               <button type="button" id="sync-to-tator-btn" disabled title="Pushes any revised data from FiftyOne back to the selected version.">Sync to Tator<span class="btn-icon end" aria-hidden="true">→</span></button>
-              <select id="dimreduce-method-select" aria-label="dimreduce-method" disabled>
-                <option value="umap">UMAP</option>
-                <option value="pca">PCA</option>
-                <option value="tsne">t-SNE</option>
-              </select>
-              <button type="button" id="dimreduce-btn" disabled title="Recompute dimensionality reduction using cached embeddings (does not recompute embeddings)">Recompute Dimreduce</button>
               <span id="sync-status" class="sync-status" aria-live="polite"></span>
               <a id="fiftyone-app-link" href="#" target="_blank" rel="noopener" class="fiftyone-app-link" style="display: none;">Open Voxel51</a>
               <button type="button" id="delete-dataset-btn" class="btn-danger" disabled title="Delete the FiftyOne dataset for the selected version. This cannot be undone. Not this only deletes the dataset from Voxel51, not Tator."><span class="btn-icon" aria-hidden="true">🗑</span>Delete Voxel51 Dataset</button>
@@ -182,8 +176,6 @@ LAUNCHER_TEMPLATE = r"""
       var vssProjectRow = document.getElementById('vss-project-row');
       var syncToTatorBtn = document.getElementById('sync-to-tator-btn');
       var deleteDatasetBtn = document.getElementById('delete-dataset-btn');
-      var dimreduceMethodSelect = document.getElementById('dimreduce-method-select');
-      var dimreduceBtn = document.getElementById('dimreduce-btn');
       var tokenInput = document.getElementById('user-token');
       var testTokenBtn = document.getElementById('test-token-btn');
       var tokenVerified = false;
@@ -297,8 +289,6 @@ LAUNCHER_TEMPLATE = r"""
         if (syncBtn) syncBtn.disabled = !tokenVerified || !hasDatabaseEntry || !embeddingServiceReady;
         if (syncToTatorBtn) syncToTatorBtn.disabled = !tokenVerified || !hasDatabaseEntry || !versionId || !selectedSyncDatasetName;
         if (deleteDatasetBtn) deleteDatasetBtn.disabled = !tokenVerified || !hasDatabaseEntry || !versionId || !datasetExists;
-        if (dimreduceMethodSelect) dimreduceMethodSelect.disabled = !tokenVerified || !hasDatabaseEntry || !versionId || !datasetExists;
-        if (dimreduceBtn) dimreduceBtn.disabled = !tokenVerified || !hasDatabaseEntry || !versionId || !datasetExists;
       }
       function setSyncControlsEnabled(enabled) {
         tokenVerified = enabled;
@@ -882,118 +872,6 @@ LAUNCHER_TEMPLATE = r"""
               deleteDatasetBtn.disabled = true;
               checkDatasetExists();
               refreshSyncDatasetChoices();
-            });
-        });
-      }
-      if (dimreduceBtn && syncStatus && syncServiceUrl && apiUrl) {
-        dimreduceBtn.addEventListener('click', function() {
-          var token = getToken();
-          if (!token || !tokenVerified) return;
-          var v = versionSelect && versionSelect.value ? versionSelect.value : '';
-          if (!v) {
-            syncStatus.textContent = 'Select a version first.';
-            syncStatus.classList.add('error');
-            return;
-          }
-          var method = dimreduceMethodSelect && dimreduceMethodSelect.value ? dimreduceMethodSelect.value : 'umap';
-          dimreduceBtn.disabled = true;
-          syncStatus.textContent = 'Recomputing dimensionality reduction…';
-          syncStatus.classList.remove('error');
-
-          var params = new URLSearchParams({
-            project_id: String(project),
-            version_id: v,
-            api_url: apiUrl,
-            token: token,
-            port: String(port),
-            method: method
-          });
-          var fullUrl = syncServiceUrl + '/dimreduce?' + params.toString();
-          fetch(fullUrl, { method: 'POST' })
-            .then(function(r) { return r.json().then(function(d) { return { ok: r.ok, data: d }; }); })
-            .then(function(result) {
-              if (!result.ok) {
-                syncStatus.textContent = 'Dimreduce failed: ' + (result.data.detail || result.data.message || 'Unknown error');
-                syncStatus.classList.add('error');
-                dimreduceBtn.disabled = false;
-                return;
-              }
-              var data = result.data || {};
-              if (data.job_id) {
-                syncStatus.textContent = 'Dimreduce queued. Waiting for worker…';
-                var syncLogPanel = document.getElementById('sync-log-panel');
-                if (syncLogPanel) { syncLogPanel.classList.remove('visible'); syncLogPanel.textContent = ''; }
-                var statusUrl = syncServiceUrl + '/dimreduce/status/' + encodeURIComponent(data.job_id);
-                var logsUrl = syncServiceUrl + '/dimreduce/logs/' + encodeURIComponent(data.job_id);
-                function updateLogPanel(cb) {
-                  fetch(logsUrl).then(function(r) { return r.ok ? r.json() : null; }).then(function(logData) {
-                    if (syncLogPanel && logData && logData.log_lines && logData.log_lines.length) {
-                      syncLogPanel.textContent = logData.log_lines.join('\\n');
-                      syncLogPanel.scrollTop = syncLogPanel.scrollHeight;
-                    }
-                    if (cb) cb();
-                  }).catch(function() { if (cb) cb(); });
-                }
-                var logPanelHideTimeout = null;
-                function hideLogPanelAfterDelay() {
-                  if (logPanelHideTimeout) clearTimeout(logPanelHideTimeout);
-                  logPanelHideTimeout = setTimeout(function() {
-                    if (syncLogPanel) syncLogPanel.classList.remove('visible');
-                    logPanelHideTimeout = null;
-                  }, 30000);
-                }
-                var poll = function() {
-                  fetch(statusUrl)
-                    .then(function(r) { return r.json(); })
-                    .then(function(s) {
-                      if (s.status === 'queued' || s.status === 'started' || s.status === 'deferred') {
-                        syncStatus.textContent = 'Dimreduce in progress…';
-                        if (syncLogPanel) syncLogPanel.classList.add('visible');
-                        updateLogPanel(function() { setTimeout(poll, 2500); });
-                        return;
-                      }
-                      if (s.status === 'failed') {
-                        syncStatus.textContent = 'Dimreduce failed: ' + (s.error || 'Unknown error');
-                        syncStatus.classList.add('error');
-                        dimreduceBtn.disabled = false;
-                        if (syncLogPanel) syncLogPanel.classList.add('visible');
-                        updateLogPanel(hideLogPanelAfterDelay);
-                        return;
-                      }
-                      if (s.status === 'finished' && s.result) {
-                        var res = s.result;
-                        var m = res && res.method ? res.method : method;
-                        syncStatus.textContent = 'Dimreduce done (' + m + ').';
-                        syncStatus.classList.remove('error');
-                        dimreduceBtn.disabled = false;
-                        if (syncLogPanel) syncLogPanel.classList.add('visible');
-                        updateLogPanel(hideLogPanelAfterDelay);
-                        setTimeout(function() { syncStatus.textContent = ''; }, 5000);
-                        return;
-                      }
-                      syncStatus.textContent = 'Dimreduce: ' + (s.status || 'unknown');
-                      if (syncLogPanel) syncLogPanel.classList.add('visible');
-                      updateLogPanel(function() { setTimeout(poll, 2500); });
-                    })
-                    .catch(function(err) {
-                      syncStatus.textContent = 'Dimreduce status check failed: ' + (err.message || 'Network error');
-                      syncStatus.classList.add('error');
-                      dimreduceBtn.disabled = false;
-                      if (syncLogPanel) syncLogPanel.classList.remove('visible');
-                    });
-                };
-                poll();
-                return;
-              }
-              // Fallback: if no job_id is returned, just show completion state
-              syncStatus.textContent = 'Dimreduce started.';
-              setTimeout(function() { syncStatus.textContent = ''; }, 3000);
-              dimreduceBtn.disabled = false;
-            })
-            .catch(function(err) {
-              syncStatus.textContent = 'Dimreduce error: ' + (err.message || 'Network error');
-              syncStatus.classList.add('error');
-              dimreduceBtn.disabled = false;
             });
         });
       }

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -272,7 +272,7 @@ async def get_vss_embedding_ws_test(
 # Optional: iframe_host, base_port (5151).
 # For "Sync from Tator" / "Sync to Tator": set sync_service_url, api_url (no token tparam).
 # User enters their Tator API token in the applet and clicks "Verify Token"; sync controls enable after token is verified.
-# Optional tparams: version_id, database_name, project_name (vss_project for embedding status only).
+# Optional tparams: version_id, section_id, query, database_name, project_name (vss_project for embedding status only).
 # database-info is called with project_id; send api_url and Authorization to resolve to config key (project name).
 # Embedding service status: server uses FASTVSS_API_URL; GET /vss-embedding shows availability.
 # FiftyOne opens in a new window/tab (Open FiftyOne button); no iframe.
@@ -415,6 +415,32 @@ async def get_versions(
     ]
 
 
+@app_launch.get("/sections")
+async def get_sections(
+    project_id: int = Query(..., description="Tator project ID"),
+    api_url: str = Query(..., description="Tator REST API base URL"),
+    authorization: str | None = Header(None, alias="Authorization"),
+) -> list[dict]:
+    """
+    Return list of Tator media sections for the given project. Used by the launcher
+    template to populate the section dropdown. Token via Authorization header.
+    """
+    import tator
+
+    token = _token_from_authorization(authorization)
+    if not token:
+        raise HTTPException(
+            status_code=401, detail="Missing or invalid Authorization header"
+        )
+    host = _resolve_api_url(api_url)
+    try:
+        api = tator.get_api(host, token)
+        section_list = api.get_section_list(project_id)
+    except Exception as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    return [{"id": s.id, "name": s.name} for s in section_list]
+
+
 @app_launch.get("/vss-projects")
 async def get_vss_projects(
     project_id: int = Query(..., description="Tator project ID"),
@@ -462,6 +488,13 @@ async def get_vss_projects(
 async def sync(
     project_id: int = Query(..., description="Tator project ID"),
     version_id: int | None = Query(None),
+    section_id: int | None = Query(
+        None, description="Optional Tator media section ID filter"
+    ),
+    query: str | None = Query(
+        None,
+        description="Optional Tator encoded_search filter (base64 Object_Search); ANDed with section when both set",
+    ),
     api_url: str = Query(
         ..., description="Tator REST API base URL (e.g. https://tator.example.com)"
     ),
@@ -542,6 +575,8 @@ async def sync(
             vss_project_key=vss_project_key,
             s3_bucket=s3_bucket,
             s3_prefix=s3_prefix,
+            section_id=section_id,
+            query=query,
         )
         return {"job_id": job_id, "status": "queued", "port": port}
     except Exception as e:

--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -37,6 +37,13 @@ from src.app.database_manager import (
     get_port_for_project,
     get_s3_config,
 )
+from src.app.sync_filters import (
+    filter_slug as _filter_slug,
+    localization_fetch_kwargs as _localization_fetch_kwargs,
+    media_fetch_kwargs as _media_fetch_kwargs,
+    scoped_data_dir,
+    version_slug as _version_slug_from_filters,
+)
 from src.app.sync_lock import (
     get_sync_lock_key,
     get_sync_to_tator_lock_key,
@@ -196,7 +203,7 @@ _SYNC_BASE = os.environ.get("FIFTYONE_SYNC_BASE", "/tmp/fiftyone_sync")
 
 
 def _version_slug(version_id: int | None) -> str:
-    return f"v{version_id}" if version_id is not None else "v_all"
+    return _version_slug_from_filters(version_id)
 
 
 def _download_dir(project_id: int) -> str:
@@ -206,23 +213,50 @@ def _download_dir(project_id: int) -> str:
     return path
 
 
-def _data_dir(project_id: int, version_id: int | None) -> str:
+def _data_dir(
+    project_id: int,
+    version_id: int | None,
+    *,
+    section_id: int | None = None,
+    query: str | None = None,
+) -> str:
     """Per-project+version directory for JSONL, crops, and manifest."""
-    path = os.path.join(_SYNC_BASE, "data", str(project_id), _version_slug(version_id))
-    os.makedirs(path, exist_ok=True)
-    return path
+    return scoped_data_dir(
+        _SYNC_BASE,
+        project_id,
+        version_id,
+        section_id=section_id,
+        query=query,
+    )
 
 
-def _crops_dir(project_id: int, version_id: int | None) -> str:
+def _crops_dir(
+    project_id: int,
+    version_id: int | None,
+    *,
+    section_id: int | None = None,
+    query: str | None = None,
+) -> str:
     """Per-project+version crops directory."""
-    path = os.path.join(_data_dir(project_id, version_id), "crops")
+    path = os.path.join(
+        _data_dir(project_id, version_id, section_id=section_id, query=query), "crops"
+    )
     os.makedirs(path, exist_ok=True)
     return path
 
 
-def _localizations_jsonl_path(project_id: int, version_id: int | None) -> str:
-    """Per-project+version JSONL path."""
-    return os.path.join(_data_dir(project_id, version_id), "localizations.jsonl")
+def _localizations_jsonl_path(
+    project_id: int,
+    version_id: int | None,
+    *,
+    section_id: int | None = None,
+    query: str | None = None,
+) -> str:
+    """Per-project+version JSONL path (optional section/query filter scope)."""
+    return os.path.join(
+        _data_dir(project_id, version_id, section_id=section_id, query=query),
+        "localizations.jsonl",
+    )
 
 
 def _file_newer_than_days(filepath: str, days: float = 1.0) -> bool:
@@ -270,6 +304,9 @@ def _get_localization_count_from_api(
     version_id: int | None,
     media_ids: list[int] | None,
     media_id_batch_size: int,
+    *,
+    section_id: int | None = None,
+    query: str | None = None,
 ) -> int | None:
     """
     Return total localization count from Tator API (same batching as fetch_and_save_localizations).
@@ -285,13 +322,14 @@ def _get_localization_count_from_api(
         else [None]
     )
 
-    def _version_kw() -> dict:
-        return {"version": [version_id]} if version_id is not None else {}
+    filter_kw = _localization_fetch_kwargs(
+        version_id=version_id, section_id=section_id, query=query
+    )
 
     try:
         loc_count = 0
         for batch in media_id_batches:
-            kw = _version_kw()
+            kw = dict(filter_kw)
             if batch:
                 kw["media_id"] = batch
             loc_count += api.get_localization_count(project_id, **kw)
@@ -307,20 +345,21 @@ def fetch_project_media_ids(
     project_id: int,
     media_ids_filter: list[int] | None = None,
     version_id: int | None = None,
+    section_id: int | None = None,
 ) -> list[int]:
     """
     Fetch all media in the project. Returns list of media ids.
     If media_ids_filter is set, only those media are returned (and must exist in the project).
     If version_id is set, filters media by that version via related_attribute.
+    If section_id is set, filters media to that Tator section.
     """
     logger.info(
-        f"fetch_project_media_ids: project_id={project_id} filter={media_ids_filter} version_id={version_id}"
+        f"fetch_project_media_ids: project_id={project_id} filter={media_ids_filter} "
+        f"version_id={version_id} section_id={section_id}"
     )
     host = api_url.rstrip("/")
     api = tator.get_api(host, token)
-    kwargs: dict = {}
-    if version_id is not None:
-        kwargs["related_attribute"] = [f"$version::{version_id}"]
+    kwargs = _media_fetch_kwargs(version_id=version_id, section_id=section_id)
     if media_ids_filter:
         # Chunk filter to avoid "Request Line is too large" from nginx (e.g. 4094 bytes).
         chunk = _MAX_SAFE_MEDIA_ID_BATCH_SIZE
@@ -995,6 +1034,8 @@ def fetch_and_save_localizations(
     media_ids: list[int] | None = None,
     localization_batch_size: int | None = None,
     media_id_batch_size: int | None = None,
+    section_id: int | None = None,
+    query: str | None = None,
 ) -> str:
     """
     Fetch all current localizations from Tator and write to a JSONL file.
@@ -1007,7 +1048,9 @@ def fetch_and_save_localizations(
     Batch sizes are from config (media_id_batch_size, localization_batch_size) or fallbacks to avoid
     414 Request-URI Too Large errors from nginx when the project has many media.
     """
-    out_path = _localizations_jsonl_path(project_id, version_id)
+    out_path = _localizations_jsonl_path(
+        project_id, version_id, section_id=section_id, query=query
+    )
     logger.info(f"Localizations JSONL will be saved to: {out_path}")
     loc_batch = (
         localization_batch_size
@@ -1037,18 +1080,20 @@ def fetch_and_save_localizations(
         f"Media ID batches: {len(media_id_batches)} batch(es) of up to {effective_mid_batch}"
     )
 
-    def _version_kw() -> dict:
-        return {"version": [version_id]} if version_id is not None else {}
+    filter_kw = _localization_fetch_kwargs(
+        version_id=version_id, section_id=section_id, query=query
+    )
 
     try:
         loc_count = 0
         for mid_batch in media_id_batches:
-            kw = _version_kw()
+            kw = dict(filter_kw)
             if mid_batch:
                 kw["media_id"] = mid_batch
             loc_count += api.get_localization_count(project_id, **kw)
         logger.info(
-            f"get_localization_count(project_id={project_id}, media_ids={bool(media_ids)}, version={version_id}) = {loc_count}"
+            f"get_localization_count(project_id={project_id}, media_ids={bool(media_ids)}, "
+            f"version={version_id}, section_id={section_id}, query={'set' if (query or '').strip() else 'none'}) = {loc_count}"
         )
         if loc_count == 0 and version_id is not None:
             count_no_ver = 0
@@ -1080,7 +1125,7 @@ def fetch_and_save_localizations(
                     kw = {"stop": loc_batch}
                     if mid_batch:
                         kw["media_id"] = mid_batch
-                    kw.update(_version_kw())
+                    kw.update(filter_kw)
                     if after_id is not None:
                         kw["after"] = after_id
                     try:
@@ -1392,17 +1437,34 @@ def _load_localizations_index(jsonl_path: str) -> dict[str, dict]:
     return index
 
 
-def _crop_manifest_path(project_id: int, version_id: int | None) -> str:
+def _crop_manifest_path(
+    project_id: int,
+    version_id: int | None,
+    *,
+    section_id: int | None = None,
+    query: str | None = None,
+) -> str:
     """Path to the crop manifest JSON for a project+version."""
-    return os.path.join(_data_dir(project_id, version_id), "crop_manifest.json")
+    return os.path.join(
+        _data_dir(project_id, version_id, section_id=section_id, query=query),
+        "crop_manifest.json",
+    )
 
 
-def _load_crop_manifest(project_id: int, version_id: int | None) -> dict[str, dict]:
+def _load_crop_manifest(
+    project_id: int,
+    version_id: int | None,
+    *,
+    section_id: int | None = None,
+    query: str | None = None,
+) -> dict[str, dict]:
     """
     Load the crop manifest from disk.
     Returns {elemental_id: {"media_id": int, "media_stem": str}} or empty dict.
     """
-    path = _crop_manifest_path(project_id, version_id)
+    path = _crop_manifest_path(
+        project_id, version_id, section_id=section_id, query=query
+    )
     if not os.path.exists(path):
         return {}
     try:
@@ -1414,10 +1476,17 @@ def _load_crop_manifest(project_id: int, version_id: int | None) -> dict[str, di
 
 
 def _save_crop_manifest(
-    project_id: int, version_id: int | None, manifest: dict[str, dict]
+    project_id: int,
+    version_id: int | None,
+    manifest: dict[str, dict],
+    *,
+    section_id: int | None = None,
+    query: str | None = None,
 ) -> None:
     """Atomically write the crop manifest to disk."""
-    path = _crop_manifest_path(project_id, version_id)
+    path = _crop_manifest_path(
+        project_id, version_id, section_id=section_id, query=query
+    )
     tmp_path = path + ".tmp"
     try:
         with open(tmp_path, "w") as f:
@@ -1735,16 +1804,21 @@ def _resolve_localizations_jsonl(
     force_sync: bool,
     media_id_batch_size: int,
     localization_batch_size: int,
+    section_id: int | None = None,
+    query: str | None = None,
 ) -> tuple[str, list[int], bool]:
     """
     Resolve localizations JSONL and media ids for crop work.
 
     Returns (localizations_path, media_ids_list, use_cached_jsonl).
     """
-    jsonl_path = _localizations_jsonl_path(project_id, version_id)
+    jsonl_path = _localizations_jsonl_path(
+        project_id, version_id, section_id=section_id, query=query
+    )
     localizations_path = ""
     media_ids_list: list[int] = []
     use_cached_jsonl = False
+    has_query = bool((query or "").strip())
     if not force_sync and _file_newer_than_days(jsonl_path, days=1.0):
         line_count, media_ids_from_jsonl = _localizations_jsonl_line_count_and_media_ids(
             jsonl_path
@@ -1753,8 +1827,10 @@ def _resolve_localizations_jsonl(
             api,
             project_id,
             version_id,
-            media_ids_from_jsonl or None,
+            None if has_query else (media_ids_from_jsonl or None),
             media_id_batch_size,
+            section_id=section_id,
+            query=query,
         )
         if api_count is not None and line_count == api_count:
             use_cached_jsonl = True
@@ -1767,24 +1843,41 @@ def _resolve_localizations_jsonl(
             )
 
     if not use_cached_jsonl:
-        logger.info(
-            "Fetching media IDs... host=%s project_id=%s api_url=%s",
-            api_url.rstrip("/"),
-            project_id,
-            api_url,
-        )
-        media_ids_list = fetch_project_media_ids(
-            api_url, token, project_id, version_id=version_id
-        )
+        loc_media_ids: list[int] | None = None
+        if not has_query:
+            logger.info(
+                "Fetching media IDs... host=%s project_id=%s api_url=%s",
+                api_url.rstrip("/"),
+                project_id,
+                api_url,
+            )
+            media_ids_list = fetch_project_media_ids(
+                api_url,
+                token,
+                project_id,
+                version_id=version_id,
+                section_id=section_id,
+            )
+            loc_media_ids = media_ids_list or None
+        else:
+            logger.info(
+                "Skipping media pre-fetch: encoded_search query filters localizations directly"
+            )
         logger.info("Fetching localizations...")
         localizations_path = fetch_and_save_localizations(
             api,
             project_id,
             version_id=version_id,
-            media_ids=media_ids_list or None,
+            media_ids=loc_media_ids,
             localization_batch_size=localization_batch_size,
             media_id_batch_size=media_id_batch_size,
+            section_id=section_id,
+            query=query,
         )
+        if has_query and localizations_path:
+            _, media_ids_list = _localizations_jsonl_line_count_and_media_ids(
+                localizations_path
+            )
     return (localizations_path, media_ids_list, use_cached_jsonl)
 
 
@@ -1863,6 +1956,8 @@ def _run_crop_pipeline(
     localization_batch_size: int,
     s3_bucket: str | None = None,
     s3_crops_prefix: str | None = None,
+    section_id: int | None = None,
+    query: str | None = None,
 ) -> dict[str, Any]:
     """
     Run crop refresh pipeline and return counts/paths/context.
@@ -1870,7 +1965,9 @@ def _run_crop_pipeline(
     This function is shared by full sync and crop-recompute jobs.
     """
     dl_dir = _download_dir(project_id)
-    crops = _crops_dir(project_id, version_id)
+    crops = _crops_dir(
+        project_id, version_id, section_id=section_id, query=query
+    )
     localizations_path = ""
     localizations_count = 0
     cache_misses = 0
@@ -1893,10 +1990,14 @@ def _run_crop_pipeline(
             force_sync=force_sync,
             media_id_batch_size=media_id_batch_size,
             localization_batch_size=localization_batch_size,
+            section_id=section_id,
+            query=query,
         )
         if localizations_path:
             logger.info("saved_localizations_path (JSONL): %s", localizations_path)
-        old_manifest = _load_crop_manifest(project_id, version_id)
+        old_manifest = _load_crop_manifest(
+            project_id, version_id, section_id=section_id, query=query
+        )
         if force:
             (
                 all_locs,
@@ -1969,7 +2070,13 @@ def _run_crop_pipeline(
             logger.info("No crop cache misses; skipping crop step")
 
         _patch_manifest_stems(updated_manifest, dl_dir, media_objects=all_media)
-        _save_crop_manifest(project_id, version_id, updated_manifest)
+        _save_crop_manifest(
+            project_id,
+            version_id,
+            updated_manifest,
+            section_id=section_id,
+            query=query,
+        )
 
         if s3_bucket and os.path.isdir(crops):
             _sync_local_dir_with_s3(crops, s3_bucket, s3_crops_prefix)
@@ -3171,6 +3278,8 @@ def run_sync_job(
     vss_project_key: str | None = None,
     s3_bucket: str | None = None,
     s3_prefix: str | None = None,
+    section_id: int | None = None,
+    query: str | None = None,
 ) -> dict[str, Any]:
     """
     Entrypoint for RQ worker: all args are serializable. Calls sync_project_to_fiftyone.
@@ -3179,7 +3288,8 @@ def run_sync_job(
     from src.app.database_manager import register_project_id_name
 
     logger.info(
-        f"run_sync_job received project_id={project_id} version_id={version_id}"
+        f"run_sync_job received project_id={project_id} version_id={version_id} "
+        f"section_id={section_id} query={'set' if (query or '').strip() else 'none'}"
     )
 
     job_meta_handler: logging.Handler | None = None
@@ -3209,6 +3319,8 @@ def run_sync_job(
             vss_project_key=vss_project_key,
             s3_bucket=s3_bucket,
             s3_prefix=s3_prefix,
+            section_id=section_id,
+            query=query,
         )
     finally:
         if job_meta_handler is not None:
@@ -3514,6 +3626,8 @@ def sync_project_to_fiftyone(
     vss_project_key: str | None = None,
     s3_bucket: str | None = None,
     s3_prefix: str | None = None,
+    section_id: int | None = None,
+    query: str | None = None,
 ) -> dict[str, Any]:
     """
     Fetch Tator media and localizations, build FiftyOne dataset, launch App on given port.
@@ -3537,7 +3651,9 @@ def sync_project_to_fiftyone(
         _s3_crops_prefix(s3_prefix, project_id, version_id) if s3_bucket else None
     )
     logger.info(
-        f"sync_project_to_fiftyone CALLED: project_id={project_id} version_id={version_id} api_url={api_url} port={port} s3_bucket={s3_bucket or 'none'}"
+        f"sync_project_to_fiftyone CALLED: project_id={project_id} version_id={version_id} "
+        f"section_id={section_id} query={'set' if (query or '').strip() else 'none'} "
+        f"api_url={api_url} port={port} s3_bucket={s3_bucket or 'none'}"
     )
     resolved_db = (
         database_name.strip() if database_name and database_name.strip() else None
@@ -3596,7 +3712,9 @@ def sync_project_to_fiftyone(
     try:
         dl_dir = ""
         localizations_path = ""
-        crops = _crops_dir(project_id, version_id)
+        crops = _crops_dir(
+            project_id, version_id, section_id=section_id, query=query
+        )
         use_cached_jsonl = False
         try:
             host = api_url.rstrip("/")
@@ -3613,6 +3731,8 @@ def sync_project_to_fiftyone(
                 localization_batch_size=localization_batch_size,
                 s3_bucket=s3_bucket,
                 s3_crops_prefix=s3_crops_prefix,
+                section_id=section_id,
+                query=query,
             )
             if crop_result.get("status") != "ok":
                 return {

--- a/src/app/sync_filters.py
+++ b/src/app/sync_filters.py
@@ -1,0 +1,73 @@
+# fiftyone-sync, Apache-2.0 license
+# Filename: src/app/sync_filters.py
+# Description: Tator section and encoded_search query filter helpers for sync.
+"""Tator section and encoded_search query filter helpers for sync."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+
+
+def version_slug(version_id: int | None) -> str:
+    return f"v{version_id}" if version_id is not None else "v_all"
+
+
+def filter_slug(section_id: int | None = None, query: str | None = None) -> str:
+    """Slug for section/query filters in on-disk cache paths."""
+    parts: list[str] = []
+    if section_id is not None:
+        parts.append(f"s{section_id}")
+    q = (query or "").strip()
+    if q:
+        parts.append("q" + hashlib.sha256(q.encode()).hexdigest()[:12])
+    return "_".join(parts)
+
+
+def localization_fetch_kwargs(
+    *,
+    version_id: int | None = None,
+    section_id: int | None = None,
+    query: str | None = None,
+) -> dict:
+    """Tator kwargs for localization list/count (version, section, encoded_search)."""
+    kw: dict = {}
+    if version_id is not None:
+        kw["version"] = [version_id]
+    if section_id is not None:
+        kw["section"] = section_id
+    q = (query or "").strip()
+    if q:
+        kw["encoded_search"] = q
+    return kw
+
+
+def media_fetch_kwargs(
+    *,
+    version_id: int | None = None,
+    section_id: int | None = None,
+) -> dict:
+    """Tator kwargs for media list (version via related_attribute, section)."""
+    kw: dict = {}
+    if version_id is not None:
+        kw["related_attribute"] = [f"$version::{version_id}"]
+    if section_id is not None:
+        kw["section"] = section_id
+    return kw
+
+
+def scoped_data_dir(
+    sync_base: str,
+    project_id: int,
+    version_id: int | None,
+    *,
+    section_id: int | None = None,
+    query: str | None = None,
+) -> str:
+    """Per-project+version directory, with optional filter subdir."""
+    path = os.path.join(sync_base, "data", str(project_id), version_slug(version_id))
+    filt = filter_slug(section_id, query)
+    if filt:
+        path = os.path.join(path, filt)
+    os.makedirs(path, exist_ok=True)
+    return path

--- a/src/app/sync_queue.py
+++ b/src/app/sync_queue.py
@@ -62,6 +62,8 @@ def enqueue_sync(
     vss_project_key: str | None = None,
     s3_bucket: str | None = None,
     s3_prefix: str | None = None,
+    section_id: int | None = None,
+    query: str | None = None,
 ) -> str:
     """
     Enqueue a sync job. Returns RQ job id. Requires Redis.
@@ -86,6 +88,8 @@ def enqueue_sync(
         vss_project_key=vss_project_key,
         s3_bucket=s3_bucket,
         s3_prefix=s3_prefix,
+        section_id=section_id,
+        query=query,
         job_timeout=3600 * 24,  # 24h for large projects
         result_ttl=3600 * 24,
         failure_ttl=3600,

--- a/tests/test_sync_filters.py
+++ b/tests/test_sync_filters.py
@@ -1,0 +1,54 @@
+# fiftyone-sync, Apache-2.0 license
+# Filename: tests/test_sync_filters.py
+# Description: Unit tests for Tator section/query sync filter helpers.
+
+from src.app.sync_filters import (
+    filter_slug,
+    localization_fetch_kwargs,
+    media_fetch_kwargs,
+    scoped_data_dir,
+)
+
+
+def test_filter_slug_empty():
+    assert filter_slug() == ""
+    assert filter_slug(section_id=None, query=None) == ""
+
+
+def test_filter_slug_section_only():
+    assert filter_slug(section_id=42) == "s42"
+
+
+def test_filter_slug_query_only():
+    slug = filter_slug(query="abc123")
+    assert slug.startswith("q")
+    assert len(slug) == 13
+
+
+def test_filter_slug_section_and_query():
+    slug = filter_slug(section_id=7, query="encoded")
+    assert slug.startswith("s7_q")
+
+
+def test_localization_fetch_kwargs_version_section_query():
+    kw = localization_fetch_kwargs(version_id=3, section_id=9, query="b64query")
+    assert kw == {"version": [3], "section": 9, "encoded_search": "b64query"}
+
+
+def test_localization_fetch_kwargs_strips_query():
+    kw = localization_fetch_kwargs(query="  q  ")
+    assert kw == {"encoded_search": "q"}
+
+
+def test_media_fetch_kwargs_version_and_section():
+    kw = media_fetch_kwargs(version_id=5, section_id=2)
+    assert kw == {"related_attribute": ["$version::5"], "section": 2}
+
+
+def test_scoped_data_dir_includes_filter_slug(tmp_path):
+    path = scoped_data_dir(
+        str(tmp_path), 1, 10, section_id=3, query="q"
+    )
+    assert path == str(
+        tmp_path / "data" / "1" / "v10" / filter_slug(section_id=3, query="q")
+    )


### PR DESCRIPTION
## Summary
- Removes the Recompute Dimreduce button and method select (UMAP/PCA/t-SNE) from the launcher UI
- Cleans up associated JS variables, state management lines, and the full click event handler
- Updates README to drop the button reference (POST /dimreduce API remains available)