### PR TITLE
feat(sync): discover versioned prediction/score pairs as indexed labels

### DIFF
--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -488,6 +488,151 @@ def _build_media_attributes_map(
     return result
 
 
+# Name of the Image media attribute that marks a project as a classification project.
+CLASSIFICATION_LABEL_ATTR = "Label"
+
+
+def is_classification_project(api: Any, project_id: int) -> bool:
+    """
+    True if the project's Image media type defines a "Label" attribute.
+
+    Such projects classify whole images: the ground-truth label lives on the
+    media (its "Label" attribute), not on localizations. For these projects sync
+    downloads each image and uses it as its own crop instead of fetching and
+    cropping localizations.
+    """
+    _, attr_names = _get_image_media_type_and_attr_names(api, project_id)
+    return CLASSIFICATION_LABEL_ATTR in attr_names
+
+
+def _media_to_classification_loc(m: Any) -> dict[str, Any] | None:
+    """
+    Build a synthetic full-frame localization for one Image media.
+
+    The label comes from the media's "Label" attribute (copied verbatim into the
+    synthetic localization's attributes). Using a full-frame box (x=0, y=0,
+    width=1, height=1) lets the rest of the pipeline (manifest, dataset build,
+    reconcile, sync-to-tator) treat the whole image as one classification sample.
+    """
+    mid = getattr(m, "id", None)
+    if mid is None:
+        return None
+    attrs = dict(getattr(m, "attributes", None) or {})
+    eid = getattr(m, "elemental_id", None)
+    eid = str(eid) if eid else f"m{mid}"
+    return {
+        "id": mid,
+        "elemental_id": eid,
+        "media": int(mid),
+        "frame": None,
+        "x": 0.0,
+        "y": 0.0,
+        "width": 1.0,
+        "height": 1.0,
+        "attributes": attrs,
+        "type": getattr(m, "type", None),
+        "version": getattr(m, "version", None),
+        "modified_datetime": getattr(m, "modified_datetime", None),
+        "created_datetime": getattr(m, "created_datetime", None),
+        "_classification": True,
+    }
+
+
+def fetch_and_save_classification_localizations(
+    api: Any,
+    project_id: int,
+    media_objects: list[Any],
+    version_id: int | None = None,
+    section_id: int | None = None,
+    query: str | None = None,
+) -> str:
+    """
+    Write one synthetic full-frame localization per Image media to a JSONL file.
+
+    Mirrors fetch_and_save_localizations (overwrites the file so it is always
+    reconciled with Tator), but for classification projects where the label is a
+    media attribute rather than a localization. Returns the JSONL path.
+    """
+    out_path = _localizations_jsonl_path(
+        project_id, version_id, section_id=section_id, query=query
+    )
+    image_type_id, _ = _get_image_media_type_and_attr_names(api, project_id)
+    logger.info(f"Classification localizations JSONL will be saved to: {out_path}")
+    total = 0
+    with open(out_path, "w") as f:
+        for m in media_objects:
+            if not isinstance(m, tator.models.Media):
+                continue
+            if image_type_id is not None and getattr(m, "type", None) != image_type_id:
+                continue
+            loc = _media_to_classification_loc(m)
+            if loc is None:
+                continue
+            try:
+                f.write(json.dumps(loc, default=_json_serial) + "\n")
+                total += 1
+            except Exception as e:
+                logger.info(f"Skip classification localization serialization: {e}")
+    logger.info(f"Wrote {total} classification localizations -> {out_path}")
+    return out_path
+
+
+def _resolve_classification_localizations_jsonl(
+    api: Any,
+    *,
+    project_id: int,
+    version_id: int | None,
+    api_url: str,
+    token: str,
+    force_sync: bool,
+    media_id_batch_size: int,
+    section_id: int | None = None,
+    query: str | None = None,
+) -> tuple[str, list[int], bool]:
+    """
+    Resolve the synthetic classification localizations JSONL and media ids.
+
+    Returns (localizations_path, media_ids_list, use_cached_jsonl). The cached
+    JSONL is reused when it is newer than one day and its line count matches the
+    current project media count (media labels are not versioned).
+    """
+    jsonl_path = _localizations_jsonl_path(
+        project_id, version_id, section_id=section_id, query=query
+    )
+    # Media labels are not versioned: fetch all project (section-scoped) media.
+    media_ids_list = fetch_project_media_ids(
+        api_url, token, project_id, section_id=section_id
+    )
+
+    if not force_sync and _file_newer_than_days(jsonl_path, days=1.0):
+        line_count, media_ids_from_jsonl = (
+            _localizations_jsonl_line_count_and_media_ids(jsonl_path)
+        )
+        if line_count > 0 and line_count == len(media_ids_list):
+            logger.info(
+                "Bypassing media fetch: classification JSONL is newer than 1 day and "
+                "line count (%s) matches project media count",
+                line_count,
+            )
+            return (jsonl_path, media_ids_from_jsonl, True)
+
+    media_objects = get_media_chunked(
+        api, project_id, media_ids_list, media_id_batch_size=media_id_batch_size
+    )
+    localizations_path = fetch_and_save_classification_localizations(
+        api,
+        project_id,
+        media_objects,
+        version_id=version_id,
+        section_id=section_id,
+        query=query,
+    )
+    _, media_ids_list = _localizations_jsonl_line_count_and_media_ids(
+        localizations_path
+    )
+    return (localizations_path, media_ids_list, False)
+
+
 # Video extensions: skip download (not supported); downloads come directly from Tator for images only.
 VIDEO_EXTENSIONS = (".mp4", ".mov", ".avi", ".webm", ".mkv", ".m4v")
 
@@ -829,6 +974,56 @@ def _safe_unlink(path: str | Path) -> None:
         pass
 
 
+def _pad_to_square(img: Image.Image) -> Image.Image:
+    """
+    Pad the shorter side of an image so it becomes square, centering the content.
+
+    Keeps aspect ratio (no distortion) before a later resize to the target size,
+    matching how localization crops are made square before resizing. Padding is
+    black (zeros), consistent with letterbox conventions.
+    """
+    width, height = img.size
+    if width == height:
+        return img
+    side = max(width, height)
+    mode = img.mode if img.mode in ("RGB", "RGBA", "L") else "RGB"
+    if img.mode != mode:
+        img = img.convert(mode)
+    fill = 0 if mode == "L" else (0, 0, 0) if mode == "RGB" else (0, 0, 0, 0)
+    canvas = Image.new(mode, (side, side), fill)
+    offset = ((side - width) // 2, (side - height) // 2)
+    canvas.paste(img, offset)
+    return canvas
+
+
+def _resize_whole_image(
+    img: Image.Image,
+    locs_with_out_paths: list[tuple[dict, Path]],
+    size: int,
+) -> tuple[int, int]:
+    """
+    Save the entire image (padded to square, then resized) for each output path.
+
+    Used for classification projects where the media image itself is the crop
+    (no localization box); see crop_localizations_parallel(classification=True).
+    The image is padded to a square to preserve aspect ratio before resizing to
+    size x size, mirroring the square-then-resize behavior of localization crops.
+    """
+    total_ok = 0
+    total_fail = 0
+    squared = _pad_to_square(img)
+    for _loc, out_path in locs_with_out_paths:
+        try:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            resized = squared.resize((size, size), _PIL_RESAMPLE)
+            resized.save(out_path, format="PNG")
+            total_ok += 1
+        except Exception as e:
+            logger.debug(f"PIL resize failed for {out_path}: {e}")
+            total_fail += 1
+    return (total_ok, total_fail)
+
+
 def _crop_media_group(
     input_path_or_url: str | Path,
     locs_with_out_paths: list[tuple[dict, Path]],
@@ -837,13 +1032,16 @@ def _crop_media_group(
     _dim_cache: dict[str, tuple[int, int]] | None = None,
     media: Any = None,
     crop_timeout: int = _DEFAULT_CROP_TIMEOUT,
+    classification: bool = False,
 ) -> tuple[int, int]:
     """
     Crop multiple localizations from one image or one video frame using PIL.
 
     For images the source file is opened directly. For video frames a single
     frame is extracted via ffmpeg to a temp file, cropped with PIL, then the
-    temp file is deleted. Returns (num_ok, num_fail).
+    temp file is deleted. When classification is True the whole image is padded
+    to a square and resized to size x size instead of cropping a localization
+    box. Returns (num_ok, num_fail).
     """
     if not locs_with_out_paths:
         return (0, 0)
@@ -863,6 +1061,11 @@ def _crop_media_group(
 
         img.load()
         width, height = img.size
+
+        if classification and not is_video:
+            result = _resize_whole_image(img, locs_with_out_paths, size)
+            img.close()
+            return result
 
         total_ok = 0
         total_fail = 0
@@ -1167,9 +1370,14 @@ def crop_localizations_parallel(
     max_workers: int | None = None,
     locs_to_crop: list[dict] | None = None,
     media_objects: list[Any] | None = None,
+    classification: bool = False,
 ) -> tuple[int, int]:
     """
     Crop localizations from their media in parallel using PIL.
+
+    When classification is True, each media image is padded to a square and
+    resized whole to size x size (no localization box crop); only image media are
+    processed in this mode.
 
     Frames are downloaded/extracted in batches of _FRAME_BATCH_SIZE to limit disk
     and memory usage. Video frames are extracted via ffmpeg to temp files, cropped
@@ -1384,7 +1592,14 @@ def crop_localizations_parallel(
             batch = image_tasks[batch_start : batch_start + batch_size]
             with ThreadPoolExecutor(max_workers=image_workers) as ex:
                 futures = [
-                    ex.submit(_crop_media_group, image_path, group, None, size)
+                    ex.submit(
+                        _crop_media_group,
+                        image_path,
+                        group,
+                        None,
+                        size,
+                        classification=classification,
+                    )
                     for image_path, group in batch
                 ]
                 ok, fail = _collect(futures)
@@ -1976,23 +2191,48 @@ def _run_crop_pipeline(
     num_cropped = 0
     num_failed = 0
     used_cached_jsonl = False
-    try:
-        (
-            localizations_path,
-            media_ids_list,
-            used_cached_jsonl,
-        ) = _resolve_localizations_jsonl(
-            api,
-            project_id=project_id,
-            version_id=version_id,
-            api_url=api_url,
-            token=token,
-            force_sync=force_sync,
-            media_id_batch_size=media_id_batch_size,
-            localization_batch_size=localization_batch_size,
-            section_id=section_id,
-            query=query,
+    classification = is_classification_project(api, project_id)
+    if classification:
+        logger.info(
+            "Project %s is a classification project (Image '%s' attribute present): "
+            "using whole-image crops, skipping localization fetch/crop",
+            project_id,
+            CLASSIFICATION_LABEL_ATTR,
         )
+    try:
+        if classification:
+            (
+                localizations_path,
+                media_ids_list,
+                used_cached_jsonl,
+            ) = _resolve_classification_localizations_jsonl(
+                api,
+                project_id=project_id,
+                version_id=version_id,
+                api_url=api_url,
+                token=token,
+                force_sync=force_sync,
+                media_id_batch_size=media_id_batch_size,
+                section_id=section_id,
+                query=query,
+            )
+        else:
+            (
+                localizations_path,
+                media_ids_list,
+                used_cached_jsonl,
+            ) = _resolve_localizations_jsonl(
+                api,
+                project_id=project_id,
+                version_id=version_id,
+                api_url=api_url,
+                token=token,
+                force_sync=force_sync,
+                media_id_batch_size=media_id_batch_size,
+                localization_batch_size=localization_batch_size,
+                section_id=section_id,
+                query=query,
+            )
         if localizations_path:
             logger.info("saved_localizations_path (JSONL): %s", localizations_path)
         old_manifest = _load_crop_manifest(
@@ -2064,6 +2304,7 @@ def _run_crop_pipeline(
                 size=224,
                 locs_to_crop=locs_to_crop,
                 media_objects=all_media,
+                classification=classification,
             )
             _cleanup_downloaded_videos(dl_dir)
         elif not locs_to_crop:
@@ -2294,6 +2535,37 @@ def _get_tator_modified_at_datetime(sample: fo.Sample) -> tuple[datetime | None,
     return None, False
 
 
+_PREDICT_WORD_RE = re.compile(r"^([A-Za-z0-9]*predict[A-Za-z0-9]*)(_.*)?$", re.IGNORECASE)
+_PREDICT_EXCLUDED = frozenset({"predicted_label"})
+
+
+def _discover_prediction_pairs(attrs: dict) -> list[tuple[str, str | None]]:
+    """
+    Scan attribute keys for any that contain the word 'predict' (case-insensitive).
+
+    For each such key a companion score key is inferred by taking the suffix that
+    follows the predict-word and prepending 'score'.  Examples:
+        prediction_v1 + score_v1  ->  ('prediction_v1', 'score_v1')
+        predict_v1    + score_v1  ->  ('predict_v1',    'score_v1')
+        prediction_v2 + score_v2  ->  ('prediction_v2', 'score_v2')
+
+    Keys already handled by the fixed top1/top2 logic ('predicted_label') are
+    excluded.  Returns a list of (pred_attr, score_attr_or_None) tuples, where
+    score_attr is only set when that key is actually present in attrs.
+    """
+    result: list[tuple[str, str | None]] = []
+    for key in attrs:
+        if key in _PREDICT_EXCLUDED:
+            continue
+        m = _PREDICT_WORD_RE.match(key)
+        if m is None:
+            continue
+        suffix = m.group(2) or ""
+        score_key = f"score{suffix}" if suffix else None
+        result.append((key, score_key if score_key and score_key in attrs else None))
+    return result
+
+
 def _apply_loc_to_sample(
     sample: fo.Sample,
     loc: dict,
@@ -2331,6 +2603,23 @@ def _apply_loc_to_sample(
         if score_s is not None:
             top2_kwargs["confidence"] = float(score_s)
         sample["top2_prediction"] = fo.Classification(**top2_kwargs)
+
+    # Dynamic prediction pairs: any attribute whose name contains 'predict'
+    # paired with a companion score attribute sharing the same suffix.
+    for pred_attr, score_attr in _discover_prediction_pairs(attrs):
+        pred_val = attrs.get(pred_attr)
+        if pred_val is None:
+            continue
+        field_name = re.sub(r"[^A-Za-z0-9_]", "_", pred_attr)
+        dyn_kwargs: dict[str, Any] = {"label": str(pred_val)}
+        if score_attr:
+            score_val = attrs.get(score_attr)
+            if score_val is not None:
+                try:
+                    dyn_kwargs["confidence"] = float(score_val)
+                except (ValueError, TypeError):
+                    pass
+        sample[field_name] = fo.Classification(**dyn_kwargs)
 
     # Primitive sample-level attributes
     _PRIMITIVE_ATTR_MAP = (
@@ -2749,7 +3038,7 @@ def build_fiftyone_dataset_from_crops(
 
 def _ensure_field_indexes(dataset: fo.Dataset) -> None:
     """Create MongoDB indexes on classification and primitive fields for faster queries."""
-    for field_path in (
+    static_paths = [
         "elemental_id",  # Used by reconcile (values aggregation) and sync-to-tator
         "ground_truth.label",
         "ground_truth.confidence",
@@ -2765,7 +3054,22 @@ def _ensure_field_indexes(dataset: fo.Dataset) -> None:
         "cluster",
         "comment",
         "verified",
-    ):
+    ]
+
+    # Discover any dynamically-added prediction Classification fields
+    dynamic_paths: list[str] = []
+    try:
+        for field_name in dataset.get_field_schema():
+            if "predict" in field_name.lower() and field_name not in {
+                "top1_prediction",
+                "top2_prediction",
+            }:
+                dynamic_paths.append(f"{field_name}.label")
+                dynamic_paths.append(f"{field_name}.confidence")
+    except Exception:
+        pass
+
+    for field_path in static_paths + dynamic_paths:
         try:
             dataset.create_index(field_path)
         except Exception:

--- a/tests/test_classify_sync.py
+++ b/tests/test_classify_sync.py
@@ -1,0 +1,179 @@
+# fiftyone-sync, Apache-2.0 license
+# Filename: tests/test_classify_sync.py
+# Description: Tests for classification-project sync (padded whole-image crops, label from media attribute).
+
+import json
+from types import SimpleNamespace
+
+import src.app.sync as sync
+
+
+def test_is_classification_project_detects_label_attr(monkeypatch):
+    monkeypatch.setattr(
+        sync,
+        "_get_image_media_type_and_attr_names",
+        lambda _api, _pid: (7, ["Label", "score"]),
+    )
+    assert sync.is_classification_project(object(), 1) is True
+
+    monkeypatch.setattr(
+        sync,
+        "_get_image_media_type_and_attr_names",
+        lambda _api, _pid: (7, ["score", "depth"]),
+    )
+    assert sync.is_classification_project(object(), 1) is False
+
+
+def test_media_to_classification_loc_full_frame_and_label():
+    media = SimpleNamespace(
+        id=42,
+        elemental_id="abc-123",
+        type=7,
+        version=3,
+        attributes={"Label": "Krill", "score": 0.9},
+        modified_datetime="2024-01-01T00:00:00Z",
+        created_datetime="2023-01-01T00:00:00Z",
+    )
+    loc = sync._media_to_classification_loc(media)
+    assert loc is not None
+    assert loc["media"] == 42
+    assert loc["elemental_id"] == "abc-123"
+    assert (loc["x"], loc["y"], loc["width"], loc["height"]) == (0.0, 0.0, 1.0, 1.0)
+    assert loc["attributes"]["Label"] == "Krill"
+    assert loc["_classification"] is True
+    # Ground truth comes from the media "Label" attribute (not a localization label).
+    assert sync._get_label_from_loc(loc) == "Krill"
+
+
+def test_media_to_classification_loc_elemental_id_fallback():
+    media = SimpleNamespace(id=99, elemental_id=None, attributes={"Label": "Salp"})
+    loc = sync._media_to_classification_loc(media)
+    assert loc["elemental_id"] == "m99"
+
+
+def test_pad_to_square_preserves_aspect_and_centers():
+    from PIL import Image
+
+    img = Image.new("RGB", (400, 100), color=(10, 20, 30))
+    squared = sync._pad_to_square(img)
+    assert squared.size == (400, 400)
+    # Content is centered vertically: rows < 150 and >= 250 are black padding.
+    assert squared.getpixel((200, 5)) == (0, 0, 0)
+    assert squared.getpixel((200, 200)) == (10, 20, 30)
+
+
+def test_classification_crop_pads_and_resizes_whole_image(tmp_path):
+    from PIL import Image
+
+    download_dir = tmp_path / "downloads"
+    download_dir.mkdir()
+    crops_dir = tmp_path / "crops"
+    crops_dir.mkdir()
+
+    # Non-square source so a plain resize (distort) differs from pad-then-resize.
+    src = download_dir / "5_image.jpg"
+    Image.new("RGB", (400, 100), color=(10, 20, 30)).save(src)
+
+    localizations = tmp_path / "localizations.jsonl"
+    loc = {
+        "elemental_id": "eid-5",
+        "media": 5,
+        "x": 0.0,
+        "y": 0.0,
+        "width": 1.0,
+        "height": 1.0,
+        "_classification": True,
+    }
+    localizations.write_text(json.dumps(loc) + "\n")
+
+    num_ok, num_fail = sync.crop_localizations_parallel(
+        str(download_dir),
+        str(localizations),
+        str(crops_dir),
+        size=224,
+        locs_to_crop=[loc],
+        classification=True,
+    )
+    assert (num_ok, num_fail) == (1, 0)
+
+    out_file = crops_dir / "5_image" / "eid-5.png"
+    assert out_file.exists()
+    with Image.open(out_file) as crop:
+        crop = crop.convert("RGB")
+        assert crop.size == (224, 224)
+        # Top band is padding (black); center band is the source color. A plain
+        # (non-padded) resize would make the whole image the source color.
+        r, g, b = crop.getpixel((112, 3))
+        assert r < 30 and g < 30 and b < 30
+        assert crop.getpixel((112, 112)) == (10, 20, 30)
+
+
+def test_run_crop_pipeline_routes_to_classification(monkeypatch, tmp_path):
+    localizations = tmp_path / "localizations.jsonl"
+    localizations.write_text("{}\n")
+    download_dir = tmp_path / "downloads"
+    download_dir.mkdir()
+    crops_dir = tmp_path / "crops"
+    crops_dir.mkdir()
+
+    loc = {"elemental_id": "eid-1", "media": 1}
+    updated_manifest = {
+        "eid-1": {"modified_at": "t1", "media_id": 1, "media_stem": "1_img"},
+    }
+
+    monkeypatch.setattr(sync, "is_classification_project", lambda _api, _pid: True)
+
+    classify_called = {}
+
+    def _fake_classify_resolve(*_args, **_kwargs):
+        classify_called["yes"] = True
+        return (str(localizations), [1], False)
+
+    def _fail_loc_resolve(*_args, **_kwargs):
+        raise AssertionError("non-classification resolver must not be called")
+
+    monkeypatch.setattr(
+        sync, "_resolve_classification_localizations_jsonl", _fake_classify_resolve
+    )
+    monkeypatch.setattr(sync, "_resolve_localizations_jsonl", _fail_loc_resolve)
+    monkeypatch.setattr(sync, "_download_dir", lambda _pid: str(download_dir))
+    monkeypatch.setattr(sync, "_crops_dir", lambda _pid, _vid, **_kw: str(crops_dir))
+    monkeypatch.setattr(sync, "_load_crop_manifest", lambda *_a, **_k: {})
+    monkeypatch.setattr(sync, "_cleanup_deleted_crops", lambda *_a, **_k: 0)
+    monkeypatch.setattr(
+        sync,
+        "_find_crop_cache_misses",
+        lambda **kwargs: ({1}, [loc], updated_manifest),
+    )
+    monkeypatch.setattr(sync, "get_media_chunked", lambda *_a, **_k: [])
+    monkeypatch.setattr(sync, "_patch_manifest_stems", lambda *_a, **_k: None)
+    monkeypatch.setattr(sync, "_save_crop_manifest", lambda *_a, **_k: None)
+    monkeypatch.setattr(sync, "_cleanup_download_dir", lambda *_a, **_k: None)
+    monkeypatch.setattr(sync, "_cleanup_downloaded_videos", lambda *_a: None)
+
+    captured = {}
+
+    def _fake_crop(*_args, **kwargs):
+        captured["classification"] = kwargs.get("classification")
+        captured["locs_to_crop"] = kwargs.get("locs_to_crop")
+        return (1, 0)
+
+    monkeypatch.setattr(sync, "crop_localizations_parallel", _fake_crop)
+
+    out = sync._run_crop_pipeline(
+        object(),
+        project_id=1,
+        version_id=42,
+        api_url="http://localhost:8080",
+        token="abc",
+        force_sync=False,
+        force=False,
+        media_id_batch_size=10,
+        localization_batch_size=10,
+        s3_bucket=None,
+        s3_crops_prefix=None,
+    )
+    assert out["status"] == "ok"
+    assert classify_called.get("yes") is True
+    assert captured["classification"] is True
+    assert captured["locs_to_crop"] == [loc]

--- a/tests/test_prediction_discovery.py
+++ b/tests/test_prediction_discovery.py
@@ -1,0 +1,167 @@
+# fiftyone-sync, Apache-2.0 license
+# Filename: tests/test_prediction_discovery.py
+# Description: Tests for dynamic prediction-pair discovery and indexed sample label assignment.
+
+import pytest
+import src.app.sync as sync
+
+
+# ---------------------------------------------------------------------------
+# _discover_prediction_pairs
+# ---------------------------------------------------------------------------
+
+
+def test_discover_prediction_pairs_versioned_suffix():
+    attrs = {"prediction_v1": "Krill", "score_v1": 0.9}
+    pairs = sync._discover_prediction_pairs(attrs)
+    assert pairs == [("prediction_v1", "score_v1")]
+
+
+def test_discover_prediction_pairs_predict_prefix_variant():
+    attrs = {"predict_v1": "Salp", "score_v1": 0.7}
+    pairs = sync._discover_prediction_pairs(attrs)
+    assert pairs == [("predict_v1", "score_v1")]
+
+
+def test_discover_prediction_pairs_multiple_versions():
+    attrs = {
+        "prediction_v1": "Krill",
+        "score_v1": 0.9,
+        "prediction_v2": "Salp",
+        "score_v2": 0.8,
+    }
+    pairs = sync._discover_prediction_pairs(attrs)
+    assert ("prediction_v1", "score_v1") in pairs
+    assert ("prediction_v2", "score_v2") in pairs
+
+
+def test_discover_prediction_pairs_missing_companion_score():
+    """No score_v1 present → score_attr should be None."""
+    attrs = {"prediction_v1": "Krill"}
+    pairs = sync._discover_prediction_pairs(attrs)
+    assert pairs == [("prediction_v1", None)]
+
+
+def test_discover_prediction_pairs_excludes_predicted_label():
+    """'predicted_label' is handled by the top1_prediction path; must not appear here."""
+    attrs = {"predicted_label": "Krill", "score": 0.9}
+    pairs = sync._discover_prediction_pairs(attrs)
+    assert all(k != "predicted_label" for k, _ in pairs)
+
+
+def test_discover_prediction_pairs_no_predict_attrs():
+    attrs = {"Label": "Krill", "score": 0.9, "depth": 3.0}
+    assert sync._discover_prediction_pairs(attrs) == []
+
+
+def test_discover_prediction_pairs_case_insensitive():
+    """Uppercase PREDICT should also be discovered."""
+    attrs = {"PREDICTION_v1": "Krill", "score_v1": 0.5}
+    pairs = sync._discover_prediction_pairs(attrs)
+    assert len(pairs) == 1
+    assert pairs[0][0] == "PREDICTION_v1"
+    assert pairs[0][1] == "score_v1"
+
+
+# ---------------------------------------------------------------------------
+# _apply_loc_to_sample – dynamic prediction field integration
+# ---------------------------------------------------------------------------
+
+
+class _MockSample(dict):
+    """Minimal fo.Sample stub: stores field assignments in a plain dict."""
+
+    def has_field(self, name):
+        return name in self
+
+    def __setitem__(self, key, value):
+        super().__setitem__(key, value)
+
+    def __getitem__(self, key):
+        return super().__getitem__(key)
+
+
+def _make_loc(attrs):
+    return {
+        "elemental_id": "eid-1",
+        "media": 1,
+        "attributes": attrs,
+        "modified_datetime": None,
+        "created_datetime": None,
+    }
+
+
+def test_apply_loc_sets_versioned_prediction_field(monkeypatch):
+    """prediction_v1 + score_v1 attrs produce a 'prediction_v1' Classification on the sample."""
+    import fiftyone as fo
+
+    attrs = {
+        "Label": "Krill",
+        "prediction_v1": "Krill_v1",
+        "score_v1": 0.85,
+    }
+    sample = fo.Sample.__new__(fo.Sample)
+    sample._doc = {}
+
+    captured = {}
+
+    def _fake_set(key, value):
+        captured[key] = value
+
+    monkeypatch.setattr(fo.Sample, "__setitem__", lambda self, k, v: captured.__setitem__(k, v))
+    monkeypatch.setattr(fo.Sample, "__getitem__", lambda self, k: captured[k])
+    monkeypatch.setattr(fo.Sample, "has_field", lambda self, k: k in captured)
+
+    sync._apply_loc_to_sample(sample, _make_loc(attrs))
+
+    assert "prediction_v1" in captured
+    cls = captured["prediction_v1"]
+    assert isinstance(cls, fo.Classification)
+    assert cls.label == "Krill_v1"
+    assert abs(cls.confidence - 0.85) < 1e-9
+
+
+def test_apply_loc_sets_multiple_versioned_prediction_fields(monkeypatch):
+    """Both prediction_v1 and prediction_v2 are applied when present."""
+    import fiftyone as fo
+
+    attrs = {
+        "Label": "Krill",
+        "prediction_v1": "A",
+        "score_v1": 0.9,
+        "prediction_v2": "B",
+        "score_v2": 0.7,
+    }
+    captured = {}
+    monkeypatch.setattr(fo.Sample, "__setitem__", lambda self, k, v: captured.__setitem__(k, v))
+    monkeypatch.setattr(fo.Sample, "__getitem__", lambda self, k: captured[k])
+    monkeypatch.setattr(fo.Sample, "has_field", lambda self, k: k in captured)
+
+    sample = fo.Sample.__new__(fo.Sample)
+    sample._doc = {}
+    sync._apply_loc_to_sample(sample, _make_loc(attrs))
+
+    assert captured["prediction_v1"].label == "A"
+    assert captured["prediction_v2"].label == "B"
+    assert abs(captured["prediction_v1"].confidence - 0.9) < 1e-9
+    assert abs(captured["prediction_v2"].confidence - 0.7) < 1e-9
+
+
+def test_apply_loc_dynamic_prediction_no_score(monkeypatch):
+    """Dynamic prediction without a companion score sets label only (no confidence)."""
+    import fiftyone as fo
+
+    attrs = {"Label": "Krill", "prediction_v1": "Krill_v1"}
+    captured = {}
+    monkeypatch.setattr(fo.Sample, "__setitem__", lambda self, k, v: captured.__setitem__(k, v))
+    monkeypatch.setattr(fo.Sample, "__getitem__", lambda self, k: captured[k])
+    monkeypatch.setattr(fo.Sample, "has_field", lambda self, k: k in captured)
+
+    sample = fo.Sample.__new__(fo.Sample)
+    sample._doc = {}
+    sync._apply_loc_to_sample(sample, _make_loc(attrs))
+
+    assert "prediction_v1" in captured
+    cls = captured["prediction_v1"]
+    assert cls.label == "Krill_v1"
+    assert cls.confidence is None

--- a/tests/test_recompute_crops.py
+++ b/tests/test_recompute_crops.py
@@ -122,8 +122,9 @@ def test_run_crop_pipeline_miss_only(monkeypatch, tmp_path):
         "_resolve_localizations_jsonl",
         lambda *args, **kwargs: (str(localizations), [1, 2], False),
     )
+    monkeypatch.setattr(sync, "is_classification_project", lambda *_a, **_k: False)
     monkeypatch.setattr(sync, "_download_dir", lambda _pid: str(download_dir))
-    monkeypatch.setattr(sync, "_crops_dir", lambda _pid, _vid: str(crops_dir))
+    monkeypatch.setattr(sync, "_crops_dir", lambda _pid, _vid, **_kw: str(crops_dir))
     monkeypatch.setattr(sync, "_load_crop_manifest", lambda *_args, **_kwargs: {})
     monkeypatch.setattr(sync, "_cleanup_deleted_crops", lambda *_args, **_kwargs: 0)
     monkeypatch.setattr(
@@ -192,8 +193,9 @@ def test_run_crop_pipeline_force_all(monkeypatch, tmp_path):
         "_resolve_localizations_jsonl",
         lambda *args, **kwargs: (str(localizations), [1], True),
     )
+    monkeypatch.setattr(sync, "is_classification_project", lambda *_a, **_k: False)
     monkeypatch.setattr(sync, "_download_dir", lambda _pid: str(download_dir))
-    monkeypatch.setattr(sync, "_crops_dir", lambda _pid, _vid: str(crops_dir))
+    monkeypatch.setattr(sync, "_crops_dir", lambda _pid, _vid, **_kw: str(crops_dir))
     monkeypatch.setattr(
         sync, "_load_crop_manifest", lambda *_args, **_kwargs: {"old": {}}
     )


### PR DESCRIPTION
Auto-detect attribute pairs like prediction_v1/score_v1 and map them to fo.Classification sample fields with MongoDB indexes for fast querying.