### PR TITLE
feat(sync): classification samples alongside localizations

### DIFF
--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -2598,6 +2598,11 @@ def _apply_loc_to_sample(
     dt = _to_datetime(modified_at)
     if dt is not None:
         sample[TATOR_MODIFIED_AT_FIELD] = dt
+    if loc.get("_classification"):
+        sample["is_classification"] = True
+        media_id = loc.get("media")
+        if media_id is not None:
+            sample["tator_media_id"] = int(media_id)
 
 
 def _create_sample_from_loc(
@@ -3104,6 +3109,16 @@ def _fetch_localizations_by_elemental_ids(
             if eid is None:
                 continue
             out[str(eid)] = loc
+        resolved_in_chunk = {str(e) for e in chunk if str(e) in out}
+        unresolved_in_chunk = [str(e) for e in chunk if str(e) not in resolved_in_chunk]
+        if unresolved_in_chunk:
+            logger.info(
+                "sync_edits_to_tator: fetch_localizations chunk %s/%s "
+                "unresolved_elemental_ids=%s",
+                i,
+                total_chunks,
+                unresolved_in_chunk,
+            )
         logger.info(
             "sync_edits_to_tator: fetch_localizations chunk %s/%s size=%s resolved_total=%s",
             i,
@@ -3112,6 +3127,143 @@ def _fetch_localizations_by_elemental_ids(
             len(out),
         )
     return out
+
+
+def _fetch_media_by_elemental_ids(
+    api: Any,
+    project_id: int,
+    elemental_ids: list[str],
+    *,
+    chunk_size: int | None = None,
+) -> dict[str, Any]:
+    """Resolve elemental_ids to media objects (classification samples use media elemental_id)."""
+    out: dict[str, Any] = {}
+    if not elemental_ids:
+        return out
+    effective_chunk = chunk_size if chunk_size is not None else _sync_to_tator_fetch_chunk()
+    unique = list(dict.fromkeys(elemental_ids))
+    total_chunks = max(1, (len(unique) + effective_chunk - 1) // effective_chunk)
+    logger.info(
+        "sync_edits_to_tator: fetch_media chunks=%s chunk_size=%s unique_ids=%s",
+        total_chunks,
+        effective_chunk,
+        len(unique),
+    )
+    for i, chunk in enumerate(_chunk_list(unique, effective_chunk), start=1):
+        media_list: list[Any] = []
+        try:
+            result = api.get_media_list_by_id(
+                project_id, media_id_query={"elemental_ids": chunk}
+            )
+            media_list = list(result) if not isinstance(result, list) else result
+        except Exception as e:
+            logger.info(
+                "sync_edits_to_tator: fetch_media batch failed (%s); "
+                "falling back to per-elemental_id get_media_list",
+                e,
+            )
+            for eid in chunk:
+                try:
+                    one = api.get_media_list(project_id, elemental_id=eid)
+                    media_list.extend(one or [])
+                except Exception as e2:
+                    logger.info(
+                        "sync_edits_to_tator: fetch_media elemental_id=%s failed: %s",
+                        eid,
+                        e2,
+                    )
+        for media in media_list:
+            eid = getattr(media, "elemental_id", None)
+            if eid is None:
+                continue
+            out[str(eid)] = media
+        unresolved_in_chunk = [str(e) for e in chunk if str(e) not in out]
+        if unresolved_in_chunk:
+            logger.info(
+                "sync_edits_to_tator: fetch_media chunk %s/%s unresolved_elemental_ids=%s",
+                i,
+                total_chunks,
+                unresolved_in_chunk,
+            )
+        logger.info(
+            "sync_edits_to_tator: fetch_media chunk %s/%s size=%s resolved_total=%s",
+            i,
+            total_chunks,
+            len(chunk),
+            len(out),
+        )
+    return out
+
+
+def _bulk_patch_media_by_elemental_id(
+    api: Any,
+    project_id: int,
+    elemental_id_to_attrs: dict[str, dict[str, Any]],
+    media_by_eid: dict[str, Any],
+    *,
+    chunk_size: int | None = None,
+    inter_chunk_delay_seconds: float | None = None,
+) -> None:
+    """
+    Apply attribute updates to Image media via PATCH /rest/Medias/{project}.
+    Groups by attribute payload and chunks by media id.
+    """
+    groups: dict[tuple[tuple[str, Any], ...], list[int]] = defaultdict(list)
+    missing: list[str] = []
+    for eid, attrs in elemental_id_to_attrs.items():
+        media = media_by_eid.get(eid)
+        if media is None:
+            missing.append(eid)
+            continue
+        mid = getattr(media, "id", None)
+        if mid is None:
+            missing.append(eid)
+            continue
+        groups[_attrs_group_key(attrs)].append(int(mid))
+
+    if missing:
+        preview = ", ".join(missing[:10])
+        suffix = "..." if len(missing) > 10 else ""
+        raise ValueError(f"No media found for elemental_id(s): {preview}{suffix}")
+
+    effective_chunk = chunk_size if chunk_size is not None else _sync_to_tator_patch_chunk()
+    effective_delay = (
+        inter_chunk_delay_seconds
+        if inter_chunk_delay_seconds is not None
+        else _sync_to_tator_chunk_delay_seconds()
+    )
+    total_chunks = sum(
+        max(1, (len(ids) + effective_chunk - 1) // effective_chunk)
+        for ids in groups.values()
+    )
+    logger.info(
+        "sync_edits_to_tator: bulk media PATCH groups=%s total_chunks=%s chunk_size=%s",
+        len(groups),
+        total_chunks,
+        effective_chunk,
+    )
+
+    sent_chunks = 0
+    for group_idx, (key, media_ids) in enumerate(groups.items(), start=1):
+        attrs = dict(key)
+        chunks = list(_chunk_list(media_ids, effective_chunk))
+        for i, chunk in enumerate(chunks):
+            api.update_media_list(
+                project_id,
+                media_bulk_update={"attributes": attrs, "ids": chunk},
+            )
+            sent_chunks += 1
+            logger.info(
+                "sync_edits_to_tator: bulk media PATCH chunk %s/%s "
+                "(group %s/%s, size=%s)",
+                sent_chunks,
+                total_chunks,
+                group_idx,
+                len(groups),
+                len(chunk),
+            )
+            if effective_delay > 0 and (i + 1) < len(chunks):
+                time.sleep(effective_delay)
 
 
 def _bulk_patch_localizations_by_elemental_id(
@@ -3435,6 +3587,20 @@ def _do_sync_edits_to_tator(
                 continue
 
         pending.append((sample, eid_str, attrs, last_modified_at))
+        if _debug:
+            logger.info(
+                "sync_edits_to_tator: PENDING elem=%s label=%s attrs=%s "
+                "is_classification=%s tator_media_id=%s",
+                eid_str,
+                label,
+                attrs,
+                bool(
+                    sample["is_classification"]
+                    if "is_classification" in sample
+                    else False
+                ),
+                sample["tator_media_id"] if "tator_media_id" in sample else None,
+            )
 
     logger.info(
         "sync_edits_to_tator: scan complete scanned=%s pending=%s skipped=%s failed=%s",
@@ -3449,33 +3615,111 @@ def _do_sync_edits_to_tator(
         for _sample, eid_str, attrs, _lm in pending:
             updates[eid_str] = attrs
 
-        try:
+        logger.info(
+            "sync_edits_to_tator: resolving %s elemental_ids -> localizations",
+            len(updates),
+        )
+        loc_by_eid = _fetch_localizations_by_elemental_ids(
+            api, project_id, version_id, list(updates.keys())
+        )
+        unresolved_for_loc = sorted(
+            eid for eid in updates if eid not in loc_by_eid
+        )
+        if unresolved_for_loc:
             logger.info(
-                "sync_edits_to_tator: resolving %s elemental_ids -> localizations",
-                len(updates),
+                "sync_edits_to_tator: %s elemental_id(s) not found as localizations; "
+                "will try media lookup: %s",
+                len(unresolved_for_loc),
+                unresolved_for_loc,
             )
-            loc_by_eid = _fetch_localizations_by_elemental_ids(
-                api, project_id, version_id, list(updates.keys())
+
+        media_by_eid: dict[str, Any] = {}
+        if unresolved_for_loc:
+            media_by_eid = _fetch_media_by_elemental_ids(
+                api, project_id, unresolved_for_loc
             )
-            logger.info(
-                "sync_edits_to_tator: bulk push samples=%s distinct_elemental_ids=%s "
-                "resolved_localizations=%s",
-                len(pending),
-                len(updates),
-                len(loc_by_eid),
+            for eid in unresolved_for_loc:
+                if eid in media_by_eid:
+                    logger.info(
+                        "sync_edits_to_tator: elemental_id=%s resolved as media "
+                        "(classification sample)",
+                        eid,
+                    )
+
+        loc_updates = {eid: attrs for eid, attrs in updates.items() if eid in loc_by_eid}
+        media_updates = {
+            eid: attrs for eid, attrs in updates.items() if eid in media_by_eid
+        }
+        unresolved = sorted(
+            eid
+            for eid in updates
+            if eid not in loc_by_eid and eid not in media_by_eid
+        )
+        if unresolved:
+            logger.warning(
+                "sync_edits_to_tator: %s elemental_id(s) unresolved (neither "
+                "localization nor media): %s",
+                len(unresolved),
+                unresolved,
             )
-            _bulk_patch_localizations_by_elemental_id(
-                api, project_id, version_id, updates, loc_by_eid
-            )
-        except Exception as e:
-            failed += len(pending)
-            errors.append(f"Batch update to Tator failed: {e}")
-        else:
+            for eid in unresolved:
+                failed += 1
+                errors.append(
+                    f"No localization or media found for elemental_id={eid}"
+                )
+
+        logger.info(
+            "sync_edits_to_tator: bulk push samples=%s distinct_elemental_ids=%s "
+            "resolved_localizations=%s resolved_media=%s unresolved=%s",
+            len(pending),
+            len(updates),
+            len(loc_by_eid),
+            len(media_by_eid),
+            len(unresolved),
+        )
+
+        successful_eids: set[str] = set()
+        if loc_updates:
+            try:
+                _bulk_patch_localizations_by_elemental_id(
+                    api, project_id, version_id, loc_updates, loc_by_eid
+                )
+            except Exception as e:
+                failed += len(loc_updates)
+                errors.append(f"Localization batch update to Tator failed: {e}")
+                logger.error(
+                    "sync_edits_to_tator: localization PATCH failed for %s "
+                    "elemental_id(s): %s",
+                    len(loc_updates),
+                    sorted(loc_updates.keys()),
+                )
+            else:
+                successful_eids.update(loc_updates.keys())
+
+        if media_updates:
+            try:
+                _bulk_patch_media_by_elemental_id(
+                    api, project_id, media_updates, media_by_eid
+                )
+            except Exception as e:
+                failed += len(media_updates)
+                errors.append(f"Media batch update to Tator failed: {e}")
+                logger.error(
+                    "sync_edits_to_tator: media PATCH failed for %s elemental_id(s): %s",
+                    len(media_updates),
+                    sorted(media_updates.keys()),
+                )
+            else:
+                successful_eids.update(media_updates.keys())
+
+        if successful_eids:
             logger.info(
                 "sync_edits_to_tator: writing tator_modified_at to %s samples",
-                len(pending),
+                len(successful_eids),
             )
-            for sample, _eid_str, _attrs, last_modified_at in pending:
+            for sample, eid_str, _attrs, last_modified_at in pending:
+                if eid_str not in successful_eids:
+                    continue
                 try:
                     sample[TATOR_MODIFIED_AT_FIELD] = last_modified_at
                     sample.save()

--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -488,6 +488,145 @@ def _build_media_attributes_map(
     return result
 
 
+# Name of the Image media attribute that marks a media as a classification sample.
+CLASSIFICATION_LABEL_ATTR = "Label"
+
+
+def is_classification_project(api: Any, project_id: int) -> bool:
+    """
+    True if the project's Image media type defines a "Label" attribute.
+
+    A project may be BOTH classification and detection: when this attribute
+    exists, labeled whole images are synced as classification samples (the media
+    image is the crop) in addition to any localizations (which are cropped as
+    usual). The two kinds of samples coexist, each identified by its elemental_id.
+    """
+    _, attr_names = _get_image_media_type_and_attr_names(api, project_id)
+    return CLASSIFICATION_LABEL_ATTR in attr_names
+
+
+def _media_to_classification_loc(m: Any) -> dict[str, Any] | None:
+    """
+    Build a synthetic full-frame localization for one Image media.
+
+    The label comes from the media's "Label" attribute (copied verbatim into the
+    synthetic localization's attributes). Using a full-frame box (x=0, y=0,
+    width=1, height=1) and the media's own elemental_id lets the rest of the
+    pipeline (manifest, dataset build, reconcile) treat the whole image as one
+    classification sample distinct from any real localizations on the same media.
+    The "_classification" flag routes cropping to a whole-image resize.
+    """
+    mid = getattr(m, "id", None)
+    if mid is None:
+        return None
+    attrs = dict(getattr(m, "attributes", None) or {})
+    eid = getattr(m, "elemental_id", None)
+    eid = str(eid) if eid else f"m{mid}"
+    return {
+        "id": mid,
+        "elemental_id": eid,
+        "media": int(mid),
+        "frame": None,
+        "x": 0.0,
+        "y": 0.0,
+        "width": 1.0,
+        "height": 1.0,
+        "attributes": attrs,
+        "type": getattr(m, "type", None),
+        "version": getattr(m, "version", None),
+        "modified_datetime": getattr(m, "modified_datetime", None),
+        "created_datetime": getattr(m, "created_datetime", None),
+        "_classification": True,
+    }
+
+
+def fetch_and_save_classification_localizations(
+    api: Any,
+    project_id: int,
+    media_objects: list[Any],
+    out_path: str | None = None,
+    mode: str = "w",
+    require_label: bool = True,
+    version_id: int | None = None,
+    section_id: int | None = None,
+    query: str | None = None,
+) -> int:
+    """
+    Write one synthetic full-frame localization per labeled Image media to JSONL.
+
+    For classification samples the label is a media attribute rather than a
+    localization. When require_label is True, only media whose "Label" attribute
+    has a non-empty value produce a sample (so detection-only images are skipped).
+    Use mode="a" to append these alongside detection localizations in the same
+    file. Returns the number of classification localizations written.
+    """
+    if out_path is None:
+        out_path = _localizations_jsonl_path(
+            project_id, version_id, section_id=section_id, query=query
+        )
+    image_type_id, _ = _get_image_media_type_and_attr_names(api, project_id)
+    logger.info(f"Classification localizations JSONL (mode={mode}): {out_path}")
+    total = 0
+    with open(out_path, mode) as f:
+        for m in media_objects:
+            if not isinstance(m, tator.models.Media):
+                continue
+            if image_type_id is not None and getattr(m, "type", None) != image_type_id:
+                continue
+            loc = _media_to_classification_loc(m)
+            if loc is None:
+                continue
+            if require_label:
+                label = (loc.get("attributes") or {}).get(CLASSIFICATION_LABEL_ATTR)
+                if label is None or not str(label).strip():
+                    continue
+            try:
+                f.write(json.dumps(loc, default=_json_serial) + "\n")
+                total += 1
+            except Exception as e:
+                logger.info(f"Skip classification localization serialization: {e}")
+    logger.info(f"Wrote {total} classification localizations -> {out_path}")
+    return total
+
+
+def _append_classification_localizations_to_jsonl(
+    api: Any,
+    *,
+    project_id: int,
+    api_url: str,
+    token: str,
+    localizations_path: str,
+    media_id_batch_size: int,
+    section_id: int | None = None,
+) -> int:
+    """
+    Append synthetic full-frame localizations for labeled Image media to the JSONL.
+
+    Detection localizations are written first (by _resolve_localizations_jsonl);
+    this adds one whole-image classification sample per labeled Image media, so a
+    project that is both classification and detection yields both kinds of
+    samples, each identified by its own elemental_id. Media labels are not
+    versioned, so all project (section-scoped) media are considered. Returns the
+    number of classification localizations appended.
+    """
+    media_ids = fetch_project_media_ids(
+        api_url, token, project_id, section_id=section_id
+    )
+    if not media_ids:
+        return 0
+    media_objects = get_media_chunked(
+        api, project_id, media_ids, media_id_batch_size=media_id_batch_size
+    )
+    return fetch_and_save_classification_localizations(
+        api,
+        project_id,
+        media_objects,
+        out_path=localizations_path,
+        mode="a",
+        require_label=True,
+    )
+
+
 # Video extensions: skip download (not supported); downloads come directly from Tator for images only.
 VIDEO_EXTENSIONS = (".mp4", ".mov", ".avi", ".webm", ".mkv", ".m4v")
 
@@ -829,6 +968,53 @@ def _safe_unlink(path: str | Path) -> None:
         pass
 
 
+def _pad_to_square(img: Image.Image) -> Image.Image:
+    """
+    Pad the shorter side of an image so it becomes square, centering the content.
+
+    Keeps aspect ratio (no distortion) before a later resize to the target size,
+    mirroring how localization crops are made square before resizing. Padding is
+    black (zeros), the standard letterbox convention.
+    """
+    width, height = img.size
+    if width == height:
+        return img
+    side = max(width, height)
+    mode = img.mode if img.mode in ("RGB", "RGBA", "L") else "RGB"
+    if img.mode != mode:
+        img = img.convert(mode)
+    fill = 0 if mode == "L" else (0, 0, 0) if mode == "RGB" else (0, 0, 0, 0)
+    canvas = Image.new(mode, (side, side), fill)
+    canvas.paste(img, ((side - width) // 2, (side - height) // 2))
+    return canvas
+
+
+def _resize_whole_image(
+    img: Image.Image,
+    locs_with_out_paths: list[tuple[dict, Path]],
+    size: int,
+) -> tuple[int, int]:
+    """
+    Save the whole image (padded to square, then resized) for each output path.
+
+    Used for classification samples where the media image itself is the crop (no
+    localization box). Padding to a square preserves aspect ratio before resizing
+    to size x size, matching the square-then-resize behavior of localization crops.
+    """
+    total_ok = 0
+    total_fail = 0
+    squared = _pad_to_square(img)
+    for _loc, out_path in locs_with_out_paths:
+        try:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            squared.resize((size, size), _PIL_RESAMPLE).save(out_path, format="PNG")
+            total_ok += 1
+        except Exception as e:
+            logger.debug(f"PIL resize failed for {out_path}: {e}")
+            total_fail += 1
+    return (total_ok, total_fail)
+
+
 def _crop_media_group(
     input_path_or_url: str | Path,
     locs_with_out_paths: list[tuple[dict, Path]],
@@ -843,7 +1029,9 @@ def _crop_media_group(
 
     For images the source file is opened directly. For video frames a single
     frame is extracted via ffmpeg to a temp file, cropped with PIL, then the
-    temp file is deleted. Returns (num_ok, num_fail).
+    temp file is deleted. Localizations flagged with "_classification" (whole-image
+    classification samples) are padded to a square and resized to size x size
+    instead of cropping a box; only image media use that path. Returns (num_ok, num_fail).
     """
     if not locs_with_out_paths:
         return (0, 0)
@@ -864,9 +1052,24 @@ def _crop_media_group(
         img.load()
         width, height = img.size
 
+        # Split into whole-image classification samples and box crops. Classification
+        # only applies to still images (video frames always crop the localization box).
+        class_items: list[tuple[dict, Path]] = []
+        box_items: list[tuple[dict, Path]] = []
+        for loc, out_path in locs_with_out_paths:
+            if not is_video and loc.get("_classification"):
+                class_items.append((loc, out_path))
+            else:
+                box_items.append((loc, out_path))
+
         total_ok = 0
         total_fail = 0
-        for loc, out_path in locs_with_out_paths:
+        if class_items:
+            ok, fail = _resize_whole_image(img, class_items, size)
+            total_ok += ok
+            total_fail += fail
+
+        for loc, out_path in box_items:
             square_coords = _compute_square_coordinates(loc, width, height)
             if square_coords is None:
                 total_fail += 1
@@ -1995,6 +2198,34 @@ def _run_crop_pipeline(
         )
         if localizations_path:
             logger.info("saved_localizations_path (JSONL): %s", localizations_path)
+
+        # Classification-and-detection projects: append one whole-image
+        # classification localization per labeled Image media alongside the
+        # detection localizations already written above. Each is identified by
+        # its own elemental_id; whole images are resized, boxes are cropped.
+        if localizations_path and is_classification_project(api, project_id):
+            added = _append_classification_localizations_to_jsonl(
+                api,
+                project_id=project_id,
+                api_url=api_url,
+                token=token,
+                localizations_path=localizations_path,
+                media_id_batch_size=media_id_batch_size,
+                section_id=section_id,
+            )
+            if added:
+                # The combined JSONL now differs from the detection-only file, so
+                # the cached-JSONL fast path no longer applies; recompute media ids.
+                used_cached_jsonl = False
+                _, media_ids_list = _localizations_jsonl_line_count_and_media_ids(
+                    localizations_path
+                )
+                logger.info(
+                    "Classification project: appended %s whole-image sample(s); "
+                    "total media ids now %s",
+                    added,
+                    len(media_ids_list),
+                )
         old_manifest = _load_crop_manifest(
             project_id, version_id, section_id=section_id, query=query
         )

--- a/tests/test_classify_sync.py
+++ b/tests/test_classify_sync.py
@@ -1,0 +1,219 @@
+# fiftyone-sync, Apache-2.0 license
+# Filename: tests/test_classify_sync.py
+# Description: Tests for combined classification+detection sync (whole-image resize + box crop, per elemental_id).
+
+import json
+from types import SimpleNamespace
+
+import src.app.sync as sync
+
+
+def test_is_classification_project_detects_label_attr(monkeypatch):
+    monkeypatch.setattr(
+        sync,
+        "_get_image_media_type_and_attr_names",
+        lambda _api, _pid: (7, ["Label", "score"]),
+    )
+    assert sync.is_classification_project(object(), 1) is True
+
+    monkeypatch.setattr(
+        sync,
+        "_get_image_media_type_and_attr_names",
+        lambda _api, _pid: (7, ["score", "depth"]),
+    )
+    assert sync.is_classification_project(object(), 1) is False
+
+
+def test_media_to_classification_loc_full_frame_and_label():
+    media = SimpleNamespace(
+        id=42,
+        elemental_id="abc-123",
+        type=7,
+        version=3,
+        attributes={"Label": "Krill", "score": 0.9},
+        modified_datetime="2024-01-01T00:00:00Z",
+        created_datetime="2023-01-01T00:00:00Z",
+    )
+    loc = sync._media_to_classification_loc(media)
+    assert loc is not None
+    assert loc["media"] == 42
+    assert loc["elemental_id"] == "abc-123"
+    assert (loc["x"], loc["y"], loc["width"], loc["height"]) == (0.0, 0.0, 1.0, 1.0)
+    assert loc["attributes"]["Label"] == "Krill"
+    assert loc["_classification"] is True
+    # Ground truth comes from the media "Label" attribute (not a localization label).
+    assert sync._get_label_from_loc(loc) == "Krill"
+
+
+def test_media_to_classification_loc_elemental_id_fallback():
+    media = SimpleNamespace(id=99, elemental_id=None, attributes={"Label": "Salp"})
+    loc = sync._media_to_classification_loc(media)
+    assert loc["elemental_id"] == "m99"
+
+
+def test_pad_to_square_preserves_aspect_and_centers():
+    from PIL import Image
+
+    img = Image.new("RGB", (400, 100), color=(10, 20, 30))
+    squared = sync._pad_to_square(img)
+    assert squared.size == (400, 400)
+    # Content is centered vertically: rows < 150 and >= 250 are black padding.
+    assert squared.getpixel((200, 5)) == (0, 0, 0)
+    assert squared.getpixel((200, 200)) == (10, 20, 30)
+
+
+class _FakeMedia(sync.tator.models.Media):
+    def __init__(self, mid, label, mtype=7, eid=None):
+        self.id = mid
+        self.elemental_id = eid or f"eid-{mid}"
+        self.type = mtype
+        self.version = 1
+        self.attributes = {"Label": label} if label is not None else {}
+        self.modified_datetime = None
+        self.created_datetime = None
+
+
+def test_fetch_and_save_classification_localizations_requires_label(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sync, "_get_image_media_type_and_attr_names", lambda _a, _p: (7, ["Label"])
+    )
+    out = tmp_path / "locs.jsonl"
+    # Seed a detection localization; classification samples must be appended, not overwrite.
+    out.write_text(json.dumps({"elemental_id": "det-1", "media": 1}) + "\n")
+
+    media = [
+        _FakeMedia(1, "Krill"),
+        _FakeMedia(2, ""),      # empty label -> skipped
+        _FakeMedia(3, None),    # no label -> skipped
+        _FakeMedia(4, "Salp", mtype=99),  # wrong media type -> skipped
+    ]
+    written = sync.fetch_and_save_classification_localizations(
+        object(), 1, media, out_path=str(out), mode="a", require_label=True
+    )
+    assert written == 1
+    lines = [json.loads(x) for x in out.read_text().splitlines() if x.strip()]
+    assert len(lines) == 2  # detection + one classification
+    assert lines[0]["elemental_id"] == "det-1"
+    assert lines[1]["_classification"] is True
+    assert lines[1]["attributes"]["Label"] == "Krill"
+
+
+def test_combined_box_and_classification_crops(tmp_path):
+    from PIL import Image
+
+    download_dir = tmp_path / "downloads"
+    download_dir.mkdir()
+    crops_dir = tmp_path / "crops"
+    crops_dir.mkdir()
+
+    # Non-square source so pad-then-resize differs from a distorting plain resize.
+    src = download_dir / "5_image.jpg"
+    Image.new("RGB", (400, 100), color=(10, 20, 30)).save(src)
+
+    box_loc = {
+        "elemental_id": "box-5",
+        "media": 5,
+        "x": 0.1,
+        "y": 0.1,
+        "width": 0.2,
+        "height": 0.2,
+    }
+    class_loc = {
+        "elemental_id": "cls-5",
+        "media": 5,
+        "x": 0.0,
+        "y": 0.0,
+        "width": 1.0,
+        "height": 1.0,
+        "_classification": True,
+    }
+    localizations = tmp_path / "localizations.jsonl"
+    localizations.write_text(
+        json.dumps(box_loc) + "\n" + json.dumps(class_loc) + "\n"
+    )
+
+    num_ok, num_fail = sync.crop_localizations_parallel(
+        str(download_dir),
+        str(localizations),
+        str(crops_dir),
+        size=224,
+        locs_to_crop=[box_loc, class_loc],
+    )
+    assert (num_ok, num_fail) == (2, 0)
+
+    box_file = crops_dir / "5_image" / "box-5.png"
+    cls_file = crops_dir / "5_image" / "cls-5.png"
+    assert box_file.exists()
+    assert cls_file.exists()
+
+    with Image.open(cls_file) as crop:
+        crop = crop.convert("RGB")
+        assert crop.size == (224, 224)
+        # Whole-image sample is padded: top band is black, center is source color.
+        r, g, b = crop.getpixel((112, 3))
+        assert r < 30 and g < 30 and b < 30
+        assert crop.getpixel((112, 112)) == (10, 20, 30)
+
+
+def test_run_crop_pipeline_appends_classification_for_labeled_project(
+    monkeypatch, tmp_path
+):
+    localizations = tmp_path / "localizations.jsonl"
+    localizations.write_text(json.dumps({"elemental_id": "det-1", "media": 1}) + "\n")
+    download_dir = tmp_path / "downloads"
+    download_dir.mkdir()
+    crops_dir = tmp_path / "crops"
+    crops_dir.mkdir()
+
+    loc = {"elemental_id": "det-1", "media": 1}
+    updated_manifest = {
+        "det-1": {"modified_at": "t1", "media_id": 1, "media_stem": "1_img"},
+    }
+
+    monkeypatch.setattr(
+        sync,
+        "_resolve_localizations_jsonl",
+        lambda *_a, **_k: (str(localizations), [1], False),
+    )
+    monkeypatch.setattr(sync, "is_classification_project", lambda _api, _pid: True)
+
+    appended = {}
+
+    def _fake_append(*_a, **kwargs):
+        appended["path"] = kwargs.get("localizations_path")
+        return 3
+
+    monkeypatch.setattr(
+        sync, "_append_classification_localizations_to_jsonl", _fake_append
+    )
+    monkeypatch.setattr(sync, "_download_dir", lambda _pid: str(download_dir))
+    monkeypatch.setattr(sync, "_crops_dir", lambda _pid, _vid, **_kw: str(crops_dir))
+    monkeypatch.setattr(sync, "_load_crop_manifest", lambda *_a, **_k: {})
+    monkeypatch.setattr(sync, "_cleanup_deleted_crops", lambda *_a, **_k: 0)
+    monkeypatch.setattr(
+        sync,
+        "_find_crop_cache_misses",
+        lambda **kwargs: ({1}, [loc], updated_manifest),
+    )
+    monkeypatch.setattr(sync, "get_media_chunked", lambda *_a, **_k: [])
+    monkeypatch.setattr(sync, "_patch_manifest_stems", lambda *_a, **_k: None)
+    monkeypatch.setattr(sync, "_save_crop_manifest", lambda *_a, **_k: None)
+    monkeypatch.setattr(sync, "_cleanup_download_dir", lambda *_a, **_k: None)
+    monkeypatch.setattr(sync, "_cleanup_downloaded_videos", lambda *_a: None)
+    monkeypatch.setattr(sync, "crop_localizations_parallel", lambda *_a, **_k: (1, 0))
+
+    out = sync._run_crop_pipeline(
+        object(),
+        project_id=1,
+        version_id=42,
+        api_url="http://localhost:8080",
+        token="abc",
+        force_sync=False,
+        force=False,
+        media_id_batch_size=10,
+        localization_batch_size=10,
+        s3_bucket=None,
+        s3_crops_prefix=None,
+    )
+    assert out["status"] == "ok"
+    assert appended.get("path") == str(localizations)

--- a/tests/test_recompute_crops.py
+++ b/tests/test_recompute_crops.py
@@ -122,8 +122,9 @@ def test_run_crop_pipeline_miss_only(monkeypatch, tmp_path):
         "_resolve_localizations_jsonl",
         lambda *args, **kwargs: (str(localizations), [1, 2], False),
     )
+    monkeypatch.setattr(sync, "is_classification_project", lambda *_a, **_k: False)
     monkeypatch.setattr(sync, "_download_dir", lambda _pid: str(download_dir))
-    monkeypatch.setattr(sync, "_crops_dir", lambda _pid, _vid: str(crops_dir))
+    monkeypatch.setattr(sync, "_crops_dir", lambda _pid, _vid, **_kw: str(crops_dir))
     monkeypatch.setattr(sync, "_load_crop_manifest", lambda *_args, **_kwargs: {})
     monkeypatch.setattr(sync, "_cleanup_deleted_crops", lambda *_args, **_kwargs: 0)
     monkeypatch.setattr(
@@ -192,8 +193,9 @@ def test_run_crop_pipeline_force_all(monkeypatch, tmp_path):
         "_resolve_localizations_jsonl",
         lambda *args, **kwargs: (str(localizations), [1], True),
     )
+    monkeypatch.setattr(sync, "is_classification_project", lambda *_a, **_k: False)
     monkeypatch.setattr(sync, "_download_dir", lambda _pid: str(download_dir))
-    monkeypatch.setattr(sync, "_crops_dir", lambda _pid, _vid: str(crops_dir))
+    monkeypatch.setattr(sync, "_crops_dir", lambda _pid, _vid, **_kw: str(crops_dir))
     monkeypatch.setattr(
         sync, "_load_crop_manifest", lambda *_args, **_kwargs: {"old": {}}
     )

--- a/tests/test_sync_to_tator.py
+++ b/tests/test_sync_to_tator.py
@@ -1,0 +1,112 @@
+# fiftyone-sync, Apache-2.0 license
+# Filename: tests/test_sync_to_tator.py
+# Description: Tests for sync-to-tator resolution of localization vs classification (media) samples.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import src.app.sync as sync
+
+
+def test_fetch_localizations_logs_unresolved(monkeypatch):
+    api = MagicMock()
+    api.get_localization_list_by_id.return_value = []
+
+    sync._fetch_localizations_by_elemental_ids(
+        api, project_id=1, version_id=2, elemental_ids=["loc-a", "loc-b"]
+    )
+
+    api.get_localization_list_by_id.assert_called_once()
+    call_kw = api.get_localization_list_by_id.call_args.kwargs
+    assert call_kw["localization_id_query"] == {"elemental_ids": ["loc-a", "loc-b"]}
+
+
+def test_fetch_media_by_elemental_ids_uses_batch_then_fallback(monkeypatch):
+    api = MagicMock()
+    api.get_media_list_by_id.side_effect = RuntimeError("batch unsupported")
+    api.get_media_list.side_effect = [
+        [SimpleNamespace(id=10, elemental_id="media-a")],
+        [],
+    ]
+
+    out = sync._fetch_media_by_elemental_ids(
+        api, project_id=1, elemental_ids=["media-a", "media-b"]
+    )
+
+    assert set(out.keys()) == {"media-a"}
+    assert out["media-a"].id == 10
+    assert api.get_media_list.call_count == 2
+
+
+def _mock_sample(elemental_id, label, *, is_classification=False, media_id=None):
+    fields = {
+        "elemental_id": elemental_id,
+        "ground_truth": SimpleNamespace(label=label, confidence=1.0),
+    }
+    if is_classification:
+        fields["is_classification"] = True
+    if media_id is not None:
+        fields["tator_media_id"] = media_id
+
+    class _Sample:
+        def __init__(self):
+            self.id = elemental_id
+            self.last_modified_at = 100.0
+            self.created_at = 1.0
+            self.save = MagicMock()
+            self._fields = fields
+
+        def __contains__(self, key):
+            return key in self._fields
+
+        def __getitem__(self, key):
+            return self._fields[key]
+
+        def __setitem__(self, key, value):
+            self._fields[key] = value
+
+    return _Sample()
+
+
+def test_do_sync_edits_routes_unresolved_to_media(monkeypatch):
+    sample_loc = _mock_sample("loc-eid", "Fish")
+    sample_cls = _mock_sample(
+        "media-eid", "Krill", is_classification=True, media_id=42
+    )
+
+    dataset = MagicMock()
+    dataset.__len__ = lambda self: 2
+    dataset.iter_samples.return_value = [sample_loc, sample_cls]
+    monkeypatch.setattr(sync.fo, "load_dataset", lambda _name: dataset)
+
+    loc_patch = MagicMock()
+    media_patch = MagicMock()
+    monkeypatch.setattr(sync, "_fetch_localizations_by_elemental_ids", lambda *_a, **_k: {})
+    monkeypatch.setattr(
+        sync,
+        "_fetch_media_by_elemental_ids",
+        lambda _api, _pid, eids: {
+            "media-eid": SimpleNamespace(id=42, elemental_id="media-eid")
+        },
+    )
+    monkeypatch.setattr(sync, "_bulk_patch_localizations_by_elemental_id", loc_patch)
+    monkeypatch.setattr(sync, "_bulk_patch_media_by_elemental_id", media_patch)
+
+    out = sync._do_sync_edits_to_tator(
+        api=MagicMock(),
+        project_id=1,
+        version_id=2,
+        ds_name="test_ds",
+        label_attr="Label",
+        score_attr="score",
+        debug=False,
+        force_sync=True,
+    )
+
+    assert loc_patch.call_count == 0
+    media_patch.assert_called_once()
+    media_eids = media_patch.call_args.args[2]
+    assert media_eids == {"media-eid": {"Label": "Krill", "score": 1.0}}
+    assert out["updated"] == 1
+    assert out["failed"] == 1
+    assert any("loc-eid" in e for e in out["errors"])


### PR DESCRIPTION
## Summary

- Projects with an Image `Label` attribute can sync **both** detection localizations (cropped boxes) and classification samples (whole images) in the same dataset, each keyed by `elemental_id`.
- Classification samples use the media `Label` attribute as ground truth; images are padded to square and resized to 224×224 instead of cropping a localization box.
- Sync-to-tator now resolves classification `elemental_id`s as media (not localizations) and pushes label updates via `update_media_list`, with added logging for unresolved ids.