### PR TITLE
feat(app): include section_id in Voxel51 dataset names

### DIFF
--- a/src/app/launcher_template.py
+++ b/src/app/launcher_template.py
@@ -108,7 +108,6 @@ LAUNCHER_TEMPLATE = r"""
               <label class="force-sync-option" title="Re-fetch media and localizations from Tator instead of using cached data when available.">
                 <input type="checkbox" id="force-sync-checkbox" name="force_sync" value="1"> Force sync
               </label>
-              <button type="button" id="sync-to-tator-btn" disabled title="Pushes any revised data from FiftyOne back to the selected version.">Sync to Tator<span class="btn-icon end" aria-hidden="true">→</span></button>
               <span id="sync-status" class="sync-status" aria-live="polite"></span>
               <a id="fiftyone-app-link" href="#" target="_blank" rel="noopener" class="fiftyone-app-link" style="display: none;">Open Voxel51</a>
             </div>
@@ -145,6 +144,7 @@ LAUNCHER_TEMPLATE = r"""
               <select id="voxel-dataset-select" aria-label="voxel-dataset" disabled title="Select the FiftyOne dataset to sync back to Tator.">
                 <option value="">Enter token and click Test</option>
               </select>
+              <button type="button" id="sync-to-tator-btn" disabled title="Pushes any revised data from FiftyOne back to the selected version.">Sync to Tator<span class="btn-icon end" aria-hidden="true">→</span></button>
               <button type="button" id="delete-dataset-btn" class="btn-danger" disabled title="Delete the FiftyOne dataset for the selected version. This cannot be undone. Not this only deletes the dataset from Voxel51, not Tator."><span class="btn-icon" aria-hidden="true">🗑</span>Delete Voxel51 Dataset</button>
             </div>
           </td>
@@ -309,7 +309,10 @@ LAUNCHER_TEMPLATE = r"""
         var token = getToken();
         var v = versionId;
         if (!syncServiceUrl || !apiUrl || !token || !v) return;
-        fetch(syncServiceUrl + '/dataset-exists?project_id=' + project + '&version_id=' + encodeURIComponent(v) + '&api_url=' + encodeURIComponent(apiUrl) + '&port=' + port, {
+        var existsUrl = syncServiceUrl + '/dataset-exists?project_id=' + project + '&version_id=' + encodeURIComponent(v) + '&api_url=' + encodeURIComponent(apiUrl) + '&port=' + port;
+        var s = sectionSelect ? sectionSelect.value : '';
+        if (s) existsUrl += '&section_id=' + encodeURIComponent(s);
+        fetch(existsUrl, {
           headers: { 'Authorization': 'Token ' + token }
         })
           .then(function(r) { return r.ok ? r.json() : null; })
@@ -457,6 +460,9 @@ LAUNCHER_TEMPLATE = r"""
       if (voxelDatasetSelect) voxelDatasetSelect.addEventListener('change', setSyncDatasetFromDropdown);
       if (vssProjectSelect) vssProjectSelect.addEventListener('change', setVssProjectFromDropdown);
       if (versionSelect) versionSelect.addEventListener('change', setVersionFromDropdown);
+      if (sectionSelect) sectionSelect.addEventListener('change', function() {
+        if (tokenVerified && hasDatabaseEntry && versionId) checkDatasetExists();
+      });
       function updateDatabaseInfo(token) {
         if (!syncServiceUrl || !token) return;
         var databaseInfoUrl = syncServiceUrl + '/database-info?project_id=' + project + '&api_url=' + encodeURIComponent(apiUrl) + '&port=' + port;
@@ -852,6 +858,8 @@ LAUNCHER_TEMPLATE = r"""
             api_url: apiUrl,
             port: String(port)
           });
+          var sec = sectionSelect ? sectionSelect.value : '';
+          if (sec) params.set('section_id', sec);
           fetch(syncServiceUrl + '/delete-dataset?' + params.toString(), {
             method: 'POST',
             headers: { 'Authorization': 'Token ' + token }

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -802,7 +802,7 @@ async def sync_to_tator(
     port: int = Query(..., description="Port for this project"),
     dataset_name: str | None = Query(
         None,
-        description="FiftyOne dataset name (default: project_name_v{version_id}_{port})",
+        description="FiftyOne dataset name (default: project_name_v{version_id}[_s{section_id}]_{port})",
     ),
     label_attr: str = Query("Label", description="Tator attribute name for label"),
     score_attr: str | None = Query(
@@ -898,9 +898,12 @@ async def dataset_exists(
     version_id: int = Query(..., description="Tator version ID"),
     api_url: str = Query(..., description="Tator REST API base URL"),
     port: int = Query(..., description="Port for this project"),
+    section_id: int | None = Query(
+        None, description="Optional Tator media section ID (matches section-scoped datasets)"
+    ),
     authorization: str | None = Header(None, alias="Authorization"),
 ) -> dict:
-    """Check whether a FiftyOne dataset exists for a specific version/port."""
+    """Check whether a FiftyOne dataset exists for a specific version/port/section."""
     token = _token_from_authorization(authorization)
     if not token:
         raise HTTPException(
@@ -936,6 +939,7 @@ async def dataset_exists(
             token=token,
             project_name=project_name,
             database_name=database_name_from_uri(database_entry.uri),
+            section_id=section_id,
         )
     except Exception as e:
         logger.warning(f"dataset_exists check failed: {e}")
@@ -1000,10 +1004,13 @@ async def delete_dataset(
     version_id: int = Query(..., description="Tator version ID"),
     api_url: str = Query(..., description="Tator REST API base URL"),
     port: int = Query(..., description="Port for this project"),
+    section_id: int | None = Query(
+        None, description="Optional Tator media section ID (matches section-scoped datasets)"
+    ),
     authorization: str | None = Header(None, alias="Authorization"),
 ) -> dict:
     """
-    Delete the FiftyOne dataset for a specific version/port. Requires authentication.
+    Delete the FiftyOne dataset for a specific version/port/section. Requires authentication.
     Returns {"status": "ok", "deleted": str | None, "database_name": str}.
     """
     token = _token_from_authorization(authorization)
@@ -1044,6 +1051,7 @@ async def delete_dataset(
             token=token,
             project_name=project_name,
             database_name=database_name_from_uri(database_entry.uri),
+            section_id=section_id,
         )
         return result
     except Exception as e:

--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -3084,8 +3084,21 @@ def _sanitize_dataset_name(name: str) -> str:
     return re.sub(r"_+", "_", s).strip("_") or "default"
 
 
-def _default_dataset_name(api: Any, project_id: int, version_id: int | None) -> str:
-    """FiftyOne dataset name (base): project_name + '_v' + version_id. Port is appended by _dataset_name_with_port."""
+def _section_slug(section_id: int | None) -> str:
+    """Section component for dataset names (e.g. s42). Empty when no section filter."""
+    return _filter_slug(section_id=section_id, query=None)
+
+
+def _default_dataset_name(
+    api: Any,
+    project_id: int,
+    version_id: int | None,
+    section_id: int | None = None,
+) -> str:
+    """FiftyOne dataset name (base): project_name + '_v' + version_id [+ '_s' + section_id].
+
+    Port is appended by _dataset_name_with_port.
+    """
     try:
         project = api.get_project(project_id)
         project_name = (
@@ -3099,7 +3112,43 @@ def _default_dataset_name(api: Any, project_id: int, version_id: int | None) -> 
         version_part = f"v{version_id}"
     else:
         version_part = "default"
-    return f"{project_name}_{version_part}"
+    base = f"{project_name}_{version_part}"
+    section_part = _section_slug(section_id)
+    if section_part:
+        return f"{base}_{section_part}"
+    return base
+
+
+def _find_dataset_match(
+    available: list[str],
+    *,
+    ds_name: str,
+    ds_name_with_port: str,
+    project_prefix: str,
+    version_id: int,
+    port: int,
+    section_id: int | None = None,
+) -> str | None:
+    """Resolve a dataset name from exact matches, then project/version/port (and section) fallback."""
+    port_suffix = f"_{port}"
+    version_part = f"_v{version_id}"
+    section_part = f"_{_section_slug(section_id)}" if section_id is not None else None
+
+    if ds_name_with_port in available:
+        return ds_name_with_port
+    if ds_name in available:
+        return ds_name
+    for d in available:
+        if not (
+            d.startswith(project_prefix)
+            and version_part in d
+            and d.endswith(port_suffix)
+        ):
+            continue
+        if section_part is not None and section_part not in d:
+            continue
+        return d
+    return None
 
 
 def _dataset_name_with_port(dataset_name: str, port: int) -> str:
@@ -4327,7 +4376,9 @@ def sync_project_to_fiftyone(
             config["s3_bucket"] = s3_bucket
             config["s3_prefix"] = s3_crops_prefix or ""
 
-        dataset_name = _default_dataset_name(api, project_id, version_id)
+        dataset_name = _default_dataset_name(
+            api, project_id, version_id, section_id=section_id
+        )
         dataset_name = _dataset_name_with_port(dataset_name, port)
 
         # Set env so FiftyOne app subprocess uses the same database (only when not production)
@@ -4644,8 +4695,9 @@ def check_dataset_exists_for_version(
     project_name: str | None = None,
     database_uri: str | None = None,
     database_name: str | None = None,
+    section_id: int | None = None,
 ) -> dict[str, Any]:
-    """Check whether a FiftyOne dataset exists for the given version/port.
+    """Check whether a FiftyOne dataset exists for the given version/port/section.
 
     Returns {"exists": bool, "dataset_name": str | None, "database_name": str}.
     """
@@ -4672,27 +4724,23 @@ def check_dataset_exists_for_version(
 
     host = api_url.rstrip("/")
     api = tator.get_api(host, token)
-    ds_name = _default_dataset_name(api, project_id, version_id)
+    ds_name = _default_dataset_name(
+        api, project_id, version_id, section_id=section_id
+    )
     ds_name_with_port = _dataset_name_with_port(ds_name, port)
     project_prefix = (
         _sanitize_dataset_name(project_name) if project_name else f"project_{project_id}"
     )
-    port_suffix = f"_{port}"
-    version_part = f"_v{version_id}"
 
-    available = fo.list_datasets()
-
-    def _find_match() -> str | None:
-        if ds_name_with_port in available:
-            return ds_name_with_port
-        if ds_name in available:
-            return ds_name
-        for d in available:
-            if d.startswith(project_prefix) and version_part in d and d.endswith(port_suffix):
-                return d
-        return None
-
-    target = _find_match()
+    target = _find_dataset_match(
+        fo.list_datasets(),
+        ds_name=ds_name,
+        ds_name_with_port=ds_name_with_port,
+        project_prefix=project_prefix,
+        version_id=version_id,
+        port=port,
+        section_id=section_id,
+    )
     return {
         "exists": target is not None,
         "dataset_name": target,
@@ -4849,8 +4897,9 @@ def delete_dataset_for_version(
     project_name: str | None = None,
     database_uri: str | None = None,
     database_name: str | None = None,
+    section_id: int | None = None,
 ) -> dict[str, Any]:
-    """Delete the FiftyOne dataset (MongoDB) and JSONL cache for a specific version/port.
+    """Delete the FiftyOne dataset (MongoDB) and JSONL cache for a specific version/port/section.
 
     Only removes the MongoDB dataset and the localizations JSONL file.
     Crop images and downloaded media are intentionally preserved.
@@ -4879,26 +4928,22 @@ def delete_dataset_for_version(
 
     host = api_url.rstrip("/")
     api = tator.get_api(host, token)
-    ds_name = _default_dataset_name(api, project_id, version_id)
+    ds_name = _default_dataset_name(
+        api, project_id, version_id, section_id=section_id
+    )
     ds_name_with_port = _dataset_name_with_port(ds_name, port)
 
     project_prefix = _sanitize_dataset_name(project_name) if project_name else f"project_{project_id}"
-    port_suffix = f"_{port}"
-    version_part = f"_v{version_id}"
 
-    available = fo.list_datasets()
-
-    def _find_match() -> str | None:
-        if ds_name_with_port in available:
-            return ds_name_with_port
-        if ds_name in available:
-            return ds_name
-        for d in available:
-            if d.startswith(project_prefix) and version_part in d and d.endswith(port_suffix):
-                return d
-        return None
-
-    target = _find_match()
+    target = _find_dataset_match(
+        fo.list_datasets(),
+        ds_name=ds_name,
+        ds_name_with_port=ds_name_with_port,
+        project_prefix=project_prefix,
+        version_id=version_id,
+        port=port,
+        section_id=section_id,
+    )
     if target is None:
         return {
             "status": "ok",


### PR DESCRIPTION
## Summary

- Include optional Tator `section_id` in default FiftyOne dataset names (`project_name_v{version_id}_s{section_id}_{port}`) so section-scoped syncs get distinct datasets.
- Thread `section_id` through `dataset-exists` and `delete-dataset` API endpoints and the launcher UI (including re-check on section change).
- Extract shared `_find_dataset_match` logic so dataset lookup respects section when resolving existing datasets.

## Test plan

- [x] Sync a version with a section selected; confirm the FiftyOne dataset name includes `_s{section_id}`.
- [x] Sync the same version without a section; confirm a separate dataset is created (no section suffix).
- [ ] Change section in the launcher after token verification; confirm dataset-exists updates correctly.
- [ ] Delete a section-scoped dataset from the launcher; confirm only that section's dataset is removed.
- [x] Sync to Tator still targets the correct dataset when a section is selected.