### PR TITLE
Add box type selector for dataset sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,8 @@ Use **Angular-style** commit messages so `python-semantic-release` can version c
  
 Do **not** use ad-hoc prefixes (`Update`, `WIP`, version-only messages) for changes that should ship.
 
+Always update the README.md or docs when adding new features or changing existing behavior.
+
 ---
 
 ## Pull requests

--- a/src/app/launcher_template.py
+++ b/src/app/launcher_template.py
@@ -101,6 +101,16 @@ LAUNCHER_TEMPLATE = r"""
           </td>
         </tr>
         <tr>
+          <th>Box type</th>
+          <td>
+            <div class="cell-controls">
+              <select id="box-type-select" aria-label="box-type" disabled title="Optional Tator box (localization) type filter. Only localizations of the selected box type are loaded into the dataset.">
+                <option value="">All box types</option>
+              </select>
+            </div>
+          </td>
+        </tr>
+        <tr>
           <th>Sync</th>
           <td>
             <div class="cell-controls">
@@ -179,6 +189,7 @@ LAUNCHER_TEMPLATE = r"""
       var fiftyoneAppLink = document.getElementById('fiftyone-app-link');
       var versionSelect = document.getElementById('version-select');
       var sectionSelect = document.getElementById('section-select');
+      var boxTypeSelect = document.getElementById('box-type-select');
       var voxelDatasetSelect = document.getElementById('voxel-dataset-select');
       var vssProjectSelect = document.getElementById('vss-project-select');
       var vssProjectRow = document.getElementById('vss-project-row');
@@ -302,6 +313,7 @@ LAUNCHER_TEMPLATE = r"""
         tokenVerified = enabled;
         if (versionSelect) versionSelect.disabled = !enabled;
         if (sectionSelect) sectionSelect.disabled = !enabled;
+        if (boxTypeSelect) boxTypeSelect.disabled = !enabled;
         if (vssProjectSelect) vssProjectSelect.disabled = !enabled;
         updateSyncButtonsState();
       }
@@ -395,6 +407,37 @@ LAUNCHER_TEMPLATE = r"""
             if (initialSectionId) sectionSelect.value = initialSectionId;
           });
       }
+      function loadBoxTypes(token) {
+        if (!boxTypeSelect || !syncServiceUrl || !apiUrl || !token) return;
+        boxTypeSelect.innerHTML = '<option value="">Loading…</option>';
+        fetch(syncServiceUrl + '/localization-types?project_id=' + project + '&api_url=' + encodeURIComponent(apiUrl), {
+          headers: { 'Authorization': 'Token ' + token }
+        })
+          .then(function(r) {
+            if (!r.ok) return r.json().then(function(d) { throw new Error(d.detail || r.statusText); });
+            return r.json();
+          })
+          .then(function(boxTypes) {
+            boxTypeSelect.innerHTML = '';
+            var allOpt = document.createElement('option');
+            allOpt.value = '';
+            allOpt.textContent = 'All box types';
+            boxTypeSelect.appendChild(allOpt);
+            (boxTypes || []).forEach(function(t) {
+              var opt = document.createElement('option');
+              opt.value = String(t.id);
+              opt.textContent = t.name + (t.id != null ? ' (' + t.id + ')' : '');
+              boxTypeSelect.appendChild(opt);
+            });
+          })
+          .catch(function() {
+            boxTypeSelect.innerHTML = '';
+            var opt = document.createElement('option');
+            opt.value = '';
+            opt.textContent = 'All box types';
+            boxTypeSelect.appendChild(opt);
+          });
+      }
       function loadVersions(token) {
         if (!versionSelect || !syncServiceUrl || !apiUrl || !token) return;
         versionSelect.innerHTML = '<option value="">Loading…</option>';
@@ -448,6 +491,13 @@ LAUNCHER_TEMPLATE = r"""
             secOpt.value = '';
             secOpt.textContent = 'Enter token and click Test';
             sectionSelect.appendChild(secOpt);
+          }
+          if (boxTypeSelect) {
+            boxTypeSelect.innerHTML = '';
+            var btOpt = document.createElement('option');
+            btOpt.value = '';
+            btOpt.textContent = 'Enter token and click Test';
+            boxTypeSelect.appendChild(btOpt);
           }
           if (vssProjectSelect && vssProjectRow) {
             vssProjectSelect.innerHTML = '<option value="">Enter token and click Test</option>';
@@ -529,6 +579,7 @@ LAUNCHER_TEMPLATE = r"""
               setSyncControlsEnabled(true);
               loadVersions(token);
               loadSections(token);
+              loadBoxTypes(token);
               loadVssProjects(token);
               syncStatus.textContent = 'Token OK. Resolving port/database…';
               updateDatabaseInfo(token);
@@ -646,6 +697,8 @@ LAUNCHER_TEMPLATE = r"""
           if (v) params.set('version_id', v);
           var s = sectionSelect ? sectionSelect.value : '';
           if (s) params.set('section_id', s);
+          var bt = boxTypeSelect ? boxTypeSelect.value : '';
+          if (bt) params.set('localization_type_id', bt);
           if (syncQuery) params.set('query', syncQuery);
           if (vssProjectKey) params.set('vss_project_key', vssProjectKey);
           var forceSyncEl = document.getElementById('force-sync-checkbox');

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -441,6 +441,37 @@ async def get_sections(
     return [{"id": s.id, "name": s.name} for s in section_list]
 
 
+@app_launch.get("/localization-types")
+async def get_localization_types(
+    project_id: int = Query(..., description="Tator project ID"),
+    api_url: str = Query(..., description="Tator REST API base URL"),
+    authorization: str | None = Header(None, alias="Authorization"),
+) -> list[dict]:
+    """
+    Return the list of Tator box (localization) types for the given project. Used by the
+    launcher template to populate the box-type dropdown. Only box-shaped localization types
+    (dtype == "box") are returned. Token via Authorization header.
+    """
+    import tator
+
+    token = _token_from_authorization(authorization)
+    if not token:
+        raise HTTPException(
+            status_code=401, detail="Missing or invalid Authorization header"
+        )
+    host = _resolve_api_url(api_url)
+    try:
+        api = tator.get_api(host, token)
+        type_list = api.get_localization_type_list(project_id)
+    except Exception as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    return [
+        {"id": t.id, "name": t.name, "dtype": getattr(t, "dtype", None)}
+        for t in type_list
+        if getattr(t, "dtype", None) == "box"
+    ]
+
+
 @app_launch.get("/vss-projects")
 async def get_vss_projects(
     project_id: int = Query(..., description="Tator project ID"),
@@ -494,6 +525,10 @@ async def sync(
     query: str | None = Query(
         None,
         description="Optional Tator encoded_search filter (base64 Object_Search); ANDed with section when both set",
+    ),
+    localization_type_id: int | None = Query(
+        None,
+        description="Optional Tator localization (box) type ID; restricts sync to a single box type",
     ),
     api_url: str = Query(
         ..., description="Tator REST API base URL (e.g. https://tator.example.com)"
@@ -577,6 +612,7 @@ async def sync(
             s3_prefix=s3_prefix,
             section_id=section_id,
             query=query,
+            localization_type_id=localization_type_id,
         )
         return {"job_id": job_id, "status": "queued", "port": port}
     except Exception as e:

--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -219,6 +219,7 @@ def _data_dir(
     *,
     section_id: int | None = None,
     query: str | None = None,
+    localization_type_id: int | None = None,
 ) -> str:
     """Per-project+version directory for JSONL, crops, and manifest."""
     return scoped_data_dir(
@@ -227,6 +228,7 @@ def _data_dir(
         version_id,
         section_id=section_id,
         query=query,
+        localization_type_id=localization_type_id,
     )
 
 
@@ -236,10 +238,18 @@ def _crops_dir(
     *,
     section_id: int | None = None,
     query: str | None = None,
+    localization_type_id: int | None = None,
 ) -> str:
     """Per-project+version crops directory."""
     path = os.path.join(
-        _data_dir(project_id, version_id, section_id=section_id, query=query), "crops"
+        _data_dir(
+            project_id,
+            version_id,
+            section_id=section_id,
+            query=query,
+            localization_type_id=localization_type_id,
+        ),
+        "crops",
     )
     os.makedirs(path, exist_ok=True)
     return path
@@ -251,10 +261,17 @@ def _localizations_jsonl_path(
     *,
     section_id: int | None = None,
     query: str | None = None,
+    localization_type_id: int | None = None,
 ) -> str:
-    """Per-project+version JSONL path (optional section/query filter scope)."""
+    """Per-project+version JSONL path (optional section/query/box-type filter scope)."""
     return os.path.join(
-        _data_dir(project_id, version_id, section_id=section_id, query=query),
+        _data_dir(
+            project_id,
+            version_id,
+            section_id=section_id,
+            query=query,
+            localization_type_id=localization_type_id,
+        ),
         "localizations.jsonl",
     )
 
@@ -307,6 +324,7 @@ def _get_localization_count_from_api(
     *,
     section_id: int | None = None,
     query: str | None = None,
+    localization_type_id: int | None = None,
 ) -> int | None:
     """
     Return total localization count from Tator API (same batching as fetch_and_save_localizations).
@@ -323,7 +341,10 @@ def _get_localization_count_from_api(
     )
 
     filter_kw = _localization_fetch_kwargs(
-        version_id=version_id, section_id=section_id, query=query
+        version_id=version_id,
+        section_id=section_id,
+        query=query,
+        localization_type_id=localization_type_id,
     )
 
     try:
@@ -1239,6 +1260,7 @@ def fetch_and_save_localizations(
     media_id_batch_size: int | None = None,
     section_id: int | None = None,
     query: str | None = None,
+    localization_type_id: int | None = None,
 ) -> str:
     """
     Fetch all current localizations from Tator and write to a JSONL file.
@@ -1247,12 +1269,17 @@ def fetch_and_save_localizations(
     Returns path to the file (e.g. .../localizations.jsonl).
     If media_ids is provided, only localizations for those media are fetched (required when syncing
     a subset of media; avoids empty results when project localizations are scoped to media).
+    If localization_type_id is provided, only localizations of that box type are fetched.
 
     Batch sizes are from config (media_id_batch_size, localization_batch_size) or fallbacks to avoid
     414 Request-URI Too Large errors from nginx when the project has many media.
     """
     out_path = _localizations_jsonl_path(
-        project_id, version_id, section_id=section_id, query=query
+        project_id,
+        version_id,
+        section_id=section_id,
+        query=query,
+        localization_type_id=localization_type_id,
     )
     logger.info(f"Localizations JSONL will be saved to: {out_path}")
     loc_batch = (
@@ -1284,7 +1311,10 @@ def fetch_and_save_localizations(
     )
 
     filter_kw = _localization_fetch_kwargs(
-        version_id=version_id, section_id=section_id, query=query
+        version_id=version_id,
+        section_id=section_id,
+        query=query,
+        localization_type_id=localization_type_id,
     )
 
     try:
@@ -2009,6 +2039,7 @@ def _resolve_localizations_jsonl(
     localization_batch_size: int,
     section_id: int | None = None,
     query: str | None = None,
+    localization_type_id: int | None = None,
 ) -> tuple[str, list[int], bool]:
     """
     Resolve localizations JSONL and media ids for crop work.
@@ -2016,7 +2047,11 @@ def _resolve_localizations_jsonl(
     Returns (localizations_path, media_ids_list, use_cached_jsonl).
     """
     jsonl_path = _localizations_jsonl_path(
-        project_id, version_id, section_id=section_id, query=query
+        project_id,
+        version_id,
+        section_id=section_id,
+        query=query,
+        localization_type_id=localization_type_id,
     )
     localizations_path = ""
     media_ids_list: list[int] = []
@@ -2034,6 +2069,7 @@ def _resolve_localizations_jsonl(
             media_id_batch_size,
             section_id=section_id,
             query=query,
+            localization_type_id=localization_type_id,
         )
         if api_count is not None and line_count == api_count:
             use_cached_jsonl = True
@@ -2076,6 +2112,7 @@ def _resolve_localizations_jsonl(
             media_id_batch_size=media_id_batch_size,
             section_id=section_id,
             query=query,
+            localization_type_id=localization_type_id,
         )
         if has_query and localizations_path:
             _, media_ids_list = _localizations_jsonl_line_count_and_media_ids(
@@ -2161,6 +2198,7 @@ def _run_crop_pipeline(
     s3_crops_prefix: str | None = None,
     section_id: int | None = None,
     query: str | None = None,
+    localization_type_id: int | None = None,
 ) -> dict[str, Any]:
     """
     Run crop refresh pipeline and return counts/paths/context.
@@ -2169,7 +2207,11 @@ def _run_crop_pipeline(
     """
     dl_dir = _download_dir(project_id)
     crops = _crops_dir(
-        project_id, version_id, section_id=section_id, query=query
+        project_id,
+        version_id,
+        section_id=section_id,
+        query=query,
+        localization_type_id=localization_type_id,
     )
     localizations_path = ""
     localizations_count = 0
@@ -2195,6 +2237,7 @@ def _run_crop_pipeline(
             localization_batch_size=localization_batch_size,
             section_id=section_id,
             query=query,
+            localization_type_id=localization_type_id,
         )
         if localizations_path:
             logger.info("saved_localizations_path (JSONL): %s", localizations_path)
@@ -3867,6 +3910,7 @@ def run_sync_job(
     s3_prefix: str | None = None,
     section_id: int | None = None,
     query: str | None = None,
+    localization_type_id: int | None = None,
 ) -> dict[str, Any]:
     """
     Entrypoint for RQ worker: all args are serializable. Calls sync_project_to_fiftyone.
@@ -3876,7 +3920,8 @@ def run_sync_job(
 
     logger.info(
         f"run_sync_job received project_id={project_id} version_id={version_id} "
-        f"section_id={section_id} query={'set' if (query or '').strip() else 'none'}"
+        f"section_id={section_id} query={'set' if (query or '').strip() else 'none'} "
+        f"localization_type_id={localization_type_id}"
     )
 
     job_meta_handler: logging.Handler | None = None
@@ -3908,6 +3953,7 @@ def run_sync_job(
             s3_prefix=s3_prefix,
             section_id=section_id,
             query=query,
+            localization_type_id=localization_type_id,
         )
     finally:
         if job_meta_handler is not None:
@@ -4215,6 +4261,7 @@ def sync_project_to_fiftyone(
     s3_prefix: str | None = None,
     section_id: int | None = None,
     query: str | None = None,
+    localization_type_id: int | None = None,
 ) -> dict[str, Any]:
     """
     Fetch Tator media and localizations, build FiftyOne dataset, launch App on given port.
@@ -4300,7 +4347,11 @@ def sync_project_to_fiftyone(
         dl_dir = ""
         localizations_path = ""
         crops = _crops_dir(
-            project_id, version_id, section_id=section_id, query=query
+            project_id,
+            version_id,
+            section_id=section_id,
+            query=query,
+            localization_type_id=localization_type_id,
         )
         use_cached_jsonl = False
         try:
@@ -4320,6 +4371,7 @@ def sync_project_to_fiftyone(
                 s3_crops_prefix=s3_crops_prefix,
                 section_id=section_id,
                 query=query,
+                localization_type_id=localization_type_id,
             )
             if crop_result.get("status") != "ok":
                 return {

--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -475,6 +475,35 @@ def _get_image_media_type_and_attr_names(
     return (None, [])
 
 
+def _get_all_media_attr_names(api: Any, project_id: int) -> set[str]:
+    """
+    Return the union of attribute names across every media type in the project
+    (Image, Video, etc.), so localizations on any media kind can be enriched with
+    their parent media's attributes. Returns an empty set on error.
+    """
+    try:
+        media_types = api.get_media_type_list(project_id)
+    except Exception as e:
+        logger.info(f"get_media_type_list failed: {e}")
+        return set()
+    names: set[str] = set()
+    for mt in media_types or []:
+        attr_types = (
+            getattr(mt, "attribute_types", None)
+            or (mt.get("attribute_types") if isinstance(mt, dict) else None)
+            or []
+        )
+        for at in attr_types:
+            n = (
+                getattr(at, "name", None)
+                if not isinstance(at, dict)
+                else at.get("name")
+            )
+            if n:
+                names.add(str(n))
+    return names
+
+
 def _build_media_attributes_map(
     api: Any,
     project_id: int,
@@ -482,11 +511,13 @@ def _build_media_attributes_map(
     media_id_batch_size: int | None = None,
 ) -> dict[int, dict[str, Any]]:
     """
-    Build media_id -> {attr_name: value} for Image media only, using project Image type schema.
-    Returns empty dict if no Image type or no media.
+    Build media_id -> {attr_name: value} for the parent media of the synced
+    localizations, across all media types (Image, Video, etc.). These attributes
+    are merged onto the localization samples so they are filterable in FiftyOne.
+    Returns an empty dict when no media schema attributes or no media are found.
     """
-    image_type_id, attr_names = _get_image_media_type_and_attr_names(api, project_id)
-    if image_type_id is None or not attr_names:
+    attr_names = _get_all_media_attr_names(api, project_id)
+    if not attr_names:
         return {}
     _, media_ids = _localizations_jsonl_line_count_and_media_ids(localizations_path)
     if not media_ids:
@@ -496,16 +527,16 @@ def _build_media_attributes_map(
     )
     result: dict[int, dict[str, Any]] = {}
     for m in all_media:
-        if getattr(m, "type", None) != image_type_id:
-            continue
         mid = getattr(m, "id", None)
         if mid is None:
             continue
         attrs = getattr(m, "attributes", None) or {}
-        result[mid] = {
+        picked = {
             k: attrs[k] for k in attr_names if k in attrs and attrs[k] is not None
         }
-    logger.info(f"Media attributes map: {len(result)} Image media with attributes")
+        if picked:
+            result[mid] = picked
+    logger.info(f"Media attributes map: {len(result)} media with attributes (all types)")
     return result
 
 
@@ -2599,6 +2630,56 @@ def _discover_prediction_pairs(attrs: dict) -> list[tuple[str, str | None]]:
     return result
 
 
+# Sample fields owned by the sync pipeline; media attributes must never clobber
+# these when merged onto a localization sample.
+_RESERVED_SAMPLE_FIELDS = frozenset(
+    {
+        "id",
+        "filepath",
+        "metadata",
+        "tags",
+        "ground_truth",
+        "top1_prediction",
+        "top2_prediction",
+        "elemental_id",
+        "media_stem",
+        "local_filepath",
+        "annotation",
+        "is_classification",
+        "tator_media_id",
+        TATOR_MODIFIED_AT_FIELD,
+    }
+)
+
+
+def _apply_media_attrs_to_sample(
+    sample: fo.Sample,
+    loc: dict,
+    media_attributes_map: dict[int, dict[str, Any]] | None,
+) -> None:
+    """
+    Merge the parent media's attributes onto a localization sample so they are
+    filterable in the FiftyOne app alongside the localization attributes.
+
+    Reserved sync-owned fields are skipped, and this is applied before the
+    localization-derived fields so a localization attribute always wins on a
+    name collision.
+    """
+    if not media_attributes_map:
+        return
+    media_id = loc.get("media")
+    if media_id is None:
+        return
+    try:
+        media_attrs = media_attributes_map.get(int(media_id)) or {}
+    except (TypeError, ValueError):
+        return
+    for k, v in media_attrs.items():
+        if v is None or k in _RESERVED_SAMPLE_FIELDS:
+            continue
+        sample[k] = v
+
+
 def _apply_loc_to_sample(
     sample: fo.Sample,
     loc: dict,
@@ -2606,8 +2687,12 @@ def _apply_loc_to_sample(
     api_url: str | None = None,
     project_id: int | None = None,
     version_id: int | None = None,
+    media_attributes_map: dict[int, dict[str, Any]] | None = None,
 ) -> None:
-    """Update an existing sample's metadata from a localization (ground_truth, top1/top2_prediction, anomaly, primitives, annotation, tator_modified_at)."""
+    """Update an existing sample's metadata from a localization (media attributes, ground_truth, top1/top2_prediction, anomaly, primitives, annotation, tator_modified_at)."""
+    # Merge parent-media attributes first so localization-derived fields below
+    # take precedence on any name collision.
+    _apply_media_attrs_to_sample(sample, loc, media_attributes_map)
     label = _get_label_from_loc(loc)
     attrs = loc.get("attributes") or {}
     eid = loc.get("elemental_id") or loc.get("id")
@@ -2706,6 +2791,7 @@ def _create_sample_from_loc(
     version_id: int | None = None,
     s3_bucket: str | None = None,
     s3_prefix: str | None = None,
+    media_attributes_map: dict[int, dict[str, Any]] | None = None,
 ) -> fo.Sample | None:
     """Create a FiftyOne sample from a localization (for reconcile add-new)."""
     elemental_id = loc.get("elemental_id") or loc.get("id")
@@ -2732,6 +2818,7 @@ def _create_sample_from_loc(
         api_url=api_url,
         project_id=project_id,
         version_id=version_id,
+        media_attributes_map=media_attributes_map,
     )
     return sample
 
@@ -2805,6 +2892,7 @@ def reconcile_dataset_with_tator(
     api_url = config.get("api_url")
     project_id = config.get("project_id")
     version_id = config.get("version_id")
+    media_attributes_map = config.get("media_attributes_map") or {}
     force_sync = bool(config.get("force_sync"))
     if force_sync:
         logger.info("Reconcile: force_sync enabled — rewriting all samples")
@@ -2856,6 +2944,7 @@ def reconcile_dataset_with_tator(
                     api_url=api_url,
                     project_id=project_id,
                     version_id=version_id,
+                    media_attributes_map=media_attributes_map,
                 )
                 sample.save()
 
@@ -2915,6 +3004,7 @@ def reconcile_dataset_with_tator(
                 version_id=version_id,
                 s3_bucket=s3_bucket,
                 s3_prefix=s3_prefix,
+                media_attributes_map=media_attributes_map,
             )
 
             if sample:
@@ -3019,12 +3109,6 @@ def build_fiftyone_dataset_from_crops(
             sample["media_stem"] = media_stem
             media_attrs_map = config.get("media_attributes_map") or {}
             if loc:
-                media_id = loc.get("media")
-                if media_id is not None:
-                    media_attrs = media_attrs_map.get(int(media_id)) or {}
-                    for k, v in media_attrs.items():
-                        if v is not None:
-                            sample[k] = v
                 if not dataset_already_exists or force_sync:
                     _apply_loc_to_sample(
                         sample,
@@ -3032,7 +3116,10 @@ def build_fiftyone_dataset_from_crops(
                         api_url=config.get("api_url"),
                         project_id=config.get("project_id"),
                         version_id=config.get("version_id"),
+                        media_attributes_map=media_attrs_map,
                     )
+                else:
+                    _apply_media_attrs_to_sample(sample, loc, media_attrs_map)
             else:
                 sample["ground_truth"] = fo.Classification(label=label, confidence=1.0)
             samples.append(sample)

--- a/src/app/sync_filters.py
+++ b/src/app/sync_filters.py
@@ -13,14 +13,20 @@ def version_slug(version_id: int | None) -> str:
     return f"v{version_id}" if version_id is not None else "v_all"
 
 
-def filter_slug(section_id: int | None = None, query: str | None = None) -> str:
-    """Slug for section/query filters in on-disk cache paths."""
+def filter_slug(
+    section_id: int | None = None,
+    query: str | None = None,
+    localization_type_id: int | None = None,
+) -> str:
+    """Slug for section/query/box-type filters in on-disk cache paths."""
     parts: list[str] = []
     if section_id is not None:
         parts.append(f"s{section_id}")
     q = (query or "").strip()
     if q:
         parts.append("q" + hashlib.sha256(q.encode()).hexdigest()[:12])
+    if localization_type_id is not None:
+        parts.append(f"t{localization_type_id}")
     return "_".join(parts)
 
 
@@ -29,8 +35,9 @@ def localization_fetch_kwargs(
     version_id: int | None = None,
     section_id: int | None = None,
     query: str | None = None,
+    localization_type_id: int | None = None,
 ) -> dict:
-    """Tator kwargs for localization list/count (version, section, encoded_search)."""
+    """Tator kwargs for localization list/count (version, section, encoded_search, type)."""
     kw: dict = {}
     if version_id is not None:
         kw["version"] = [version_id]
@@ -39,6 +46,8 @@ def localization_fetch_kwargs(
     q = (query or "").strip()
     if q:
         kw["encoded_search"] = q
+    if localization_type_id is not None:
+        kw["type"] = [localization_type_id]
     return kw
 
 
@@ -63,10 +72,11 @@ def scoped_data_dir(
     *,
     section_id: int | None = None,
     query: str | None = None,
+    localization_type_id: int | None = None,
 ) -> str:
     """Per-project+version directory, with optional filter subdir."""
     path = os.path.join(sync_base, "data", str(project_id), version_slug(version_id))
-    filt = filter_slug(section_id, query)
+    filt = filter_slug(section_id, query, localization_type_id)
     if filt:
         path = os.path.join(path, filt)
     os.makedirs(path, exist_ok=True)

--- a/src/app/sync_queue.py
+++ b/src/app/sync_queue.py
@@ -64,11 +64,13 @@ def enqueue_sync(
     s3_prefix: str | None = None,
     section_id: int | None = None,
     query: str | None = None,
+    localization_type_id: int | None = None,
 ) -> str:
     """
     Enqueue a sync job. Returns RQ job id. Requires Redis.
     project_name is used by the worker to resolve get_database_uri(project_id, port).
     vss_project_key is used to select a specific VSS project configuration for embeddings.
+    localization_type_id restricts the sync to a single Tator box (localization) type.
     """
     from rq import Queue
 
@@ -90,6 +92,7 @@ def enqueue_sync(
         s3_prefix=s3_prefix,
         section_id=section_id,
         query=query,
+        localization_type_id=localization_type_id,
         job_timeout=3600 * 24,  # 24h for large projects
         result_ttl=3600 * 24,
         failure_ttl=3600,

--- a/tests/test_classify_sync.py
+++ b/tests/test_classify_sync.py
@@ -155,6 +155,62 @@ def test_combined_box_and_classification_crops(tmp_path):
         assert crop.getpixel((112, 112)) == (10, 20, 30)
 
 
+def test_apply_media_attrs_merges_and_skips_reserved():
+    import fiftyone as fo
+
+    sample = fo.Sample(filepath="/tmp/nonexistent.png")
+    media_map = {5: {"depth": 12.5, "camera": "cam-A", "ground_truth": "SHOULD_SKIP"}}
+    sync._apply_media_attrs_to_sample(sample, {"media": 5}, media_map)
+    assert sample["depth"] == 12.5
+    assert sample["camera"] == "cam-A"
+    # Reserved sync-owned field must not be clobbered by a media attribute.
+    assert not sample.has_field("ground_truth") or sample["ground_truth"] != "SHOULD_SKIP"
+
+
+def test_apply_loc_to_sample_localization_attr_wins_over_media():
+    import fiftyone as fo
+
+    sample = fo.Sample(filepath="/tmp/nonexistent.png")
+    loc = {
+        "media": 5,
+        "elemental_id": "box-1",
+        "attributes": {"Label": "Krill", "depth": 3.0},
+    }
+    # Media also carries depth; the localization value must win.
+    media_map = {5: {"depth": 99.0, "survey": "dive-42"}}
+    sync._apply_loc_to_sample(sample, loc, media_attributes_map=media_map)
+    assert sample["survey"] == "dive-42"
+    assert sample["depth"] == 3.0
+    assert sample["ground_truth"].label == "Krill"
+
+
+def test_build_media_attributes_map_covers_all_media_types(monkeypatch, tmp_path):
+    localizations = tmp_path / "localizations.jsonl"
+    localizations.write_text(
+        json.dumps({"elemental_id": "box-1", "media": 1}) + "\n"
+        + json.dumps({"elemental_id": "box-2", "media": 2}) + "\n"
+    )
+
+    video_type = SimpleNamespace(
+        name="Video", attribute_types=[SimpleNamespace(name="depth")]
+    )
+    image_type = SimpleNamespace(
+        name="Image", attribute_types=[SimpleNamespace(name="Label")]
+    )
+
+    api = SimpleNamespace(get_media_type_list=lambda _pid: [video_type, image_type])
+    monkeypatch.setattr(
+        sync,
+        "get_media_chunked",
+        lambda *_a, **_k: [
+            SimpleNamespace(id=1, type=10, attributes={"depth": 5.0}),
+            SimpleNamespace(id=2, type=7, attributes={"Label": "Salp"}),
+        ],
+    )
+    result = sync._build_media_attributes_map(api, 1, str(localizations))
+    assert result == {1: {"depth": 5.0}, 2: {"Label": "Salp"}}
+
+
 def test_run_crop_pipeline_appends_classification_for_labeled_project(
     monkeypatch, tmp_path
 ):

--- a/tests/test_sync_filters.py
+++ b/tests/test_sync_filters.py
@@ -30,9 +30,22 @@ def test_filter_slug_section_and_query():
     assert slug.startswith("s7_q")
 
 
+def test_filter_slug_localization_type_only():
+    assert filter_slug(localization_type_id=15) == "t15"
+
+
+def test_filter_slug_section_and_localization_type():
+    assert filter_slug(section_id=7, localization_type_id=15) == "s7_t15"
+
+
 def test_localization_fetch_kwargs_version_section_query():
     kw = localization_fetch_kwargs(version_id=3, section_id=9, query="b64query")
     assert kw == {"version": [3], "section": 9, "encoded_search": "b64query"}
+
+
+def test_localization_fetch_kwargs_localization_type():
+    kw = localization_fetch_kwargs(version_id=3, localization_type_id=15)
+    assert kw == {"version": [3], "type": [15]}
 
 
 def test_localization_fetch_kwargs_strips_query():


### PR DESCRIPTION
## Summary
- Adds a **Box type** dropdown to the launcher so users can choose which Tator localization (box) type is loaded into the FiftyOne dataset, supporting projects with multiple box types (e.g. Box and TDWABox).
- Introduces `GET /localization-types` and threads `localization_type_id` through the sync queue and pipeline, including cache scoping so different box-type selections do not collide on disk.
- Merges parent media attributes onto localization samples so media and localization fields are filterable together in Voxel51, across fresh build and reconcile add/update paths.

Closes #23