### PR TITLE
feat: filter verified samples in CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Optional query param **`database_name`** on `GET /launch` and `POST /sync` overr
 | `section_id` | no | Tator media section ID; ANDed with `query` when both set |
 | `query` | no | Tator `encoded_search` filter (base64 Object_Search); ANDed with `section_id` when both set |
 | `localization_type_id` | no | Restrict sync to a single Tator box (localization) type |
-| `verified_only` | no | Only include localizations whose `verified` attribute is truthy in the built dataset (default: false). Exposed as the **Verified only** checkbox in the launcher applet. |
+| `verified_only` | no | Only include localizations whose `verified` attribute is truthy in the built dataset (default: false). Exposed as the **Verified only** checkbox in the launcher applet. On subsequent syncs, samples that later become unverified are removed from the dataset (they are re-added automatically if re-verified). |
 | `database_name` | no | Override MongoDB database name |
 | `config_path` | no | Path to YAML/JSON config file for dataset build |
 | `launch_app` | no | Launch FiftyOne app after sync (default: true) |

--- a/README.md
+++ b/README.md
@@ -416,3 +416,16 @@ curl -X POST http://localhost:8000/embed \
 curl http://localhost:8000/embed/{uuid}
 # Returns: {"status": "completed", "embeddings": [[...], [...]]}
 ```
+
+## Scripts
+
+One-off utility scripts in `scripts/` for direct MongoDB/FiftyOne Enterprise access (outside the sync service).
+
+- `scripts/set_verified.py` — Sets `verified=True` on every sample in specific FiftyOne Enterprise datasets. Requires `FIFTYONE_API_KEY`.
+- `scripts/export_dataset_csv.py` — Exports a FiftyOne dataset to CSV (metadata only; no images, no embeddings).
+  - `--verified-only` — Exclude samples that are not marked `verified=True` (samples missing the `verified` field are treated as unverified).
+
+  ```bash
+  python scripts/export_dataset_csv.py -o ~/Desktop/export.csv
+  python scripts/export_dataset_csv.py --verified-only -o ~/Desktop/export_verified.csv
+  ```

--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ Optional query param **`database_name`** on `GET /launch` and `POST /sync` overr
 | `version_id` | no | Version ID filter for localizations |
 | `section_id` | no | Tator media section ID; ANDed with `query` when both set |
 | `query` | no | Tator `encoded_search` filter (base64 Object_Search); ANDed with `section_id` when both set |
+| `localization_type_id` | no | Restrict sync to a single Tator box (localization) type |
+| `verified_only` | no | Only include localizations whose `verified` attribute is truthy in the built dataset (default: false). Exposed as the **Verified only** checkbox in the launcher applet. |
 | `database_name` | no | Override MongoDB database name |
 | `config_path` | no | Path to YAML/JSON config file for dataset build |
 | `launch_app` | no | Launch FiftyOne app after sync (default: true) |
@@ -296,6 +298,8 @@ include_classes: [Larvacean, Copepod]   # optional: filter labels
 image_extensions: ["*.png", "*.jpg"]
 max_samples: 500                         # optional: limit for testing
 ```
+
+`verified_only` is set from the `verified_only` query param (or the applet's **Verified only** checkbox), not from this config file.
 
 The FiftyOne dataset name is always `project_name_v{version_id}_{port}` and cannot be set in config.
 

--- a/scripts/export_dataset_csv.py
+++ b/scripts/export_dataset_csv.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# fiftyone-sync, Apache-2.0 license
+# Filename: scripts/export_dataset_csv.py
+# Description: Export a FiftyOne dataset to CSV (no images, no embeddings) from a remote MongoDB with no auth.
+"""
+One-shot export of dataset metadata to CSV.
+
+Connects to MongoDB with no password, loads the dataset, and writes a CSV that
+excludes image media and embedding/vector fields.
+
+By default, all samples are exported. Pass --verified-only to exclude samples
+that have not been marked `verified=True` (e.g. via scripts/set_verified.py).
+
+Usage:
+  python scripts/export_dataset_csv.py
+  python scripts/export_dataset_csv.py -o ~/Desktop/isiis.csv
+  python scripts/export_dataset_csv.py --verified-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# --- connection (no password) ---
+MONGO_URI = "mongodb://maximilian.shore.mbari.org:27017"
+DATABASE_NAME = "fiftyone"
+DATASET_NAME = "902111-ISIIS-Deployments_v67_5151"
+DEFAULT_OUT = Path.cwd() / f"{DATASET_NAME}.csv"
+
+# Field names / substrings to drop from the CSV (case-insensitive match on name).
+EXCLUDE_NAME_PARTS = (
+    "embedding",
+    "embeddings",
+    "filepath",  # crop image path; drop so export is metadata-only
+)
+
+
+def _configure_fiftyone() -> None:
+    os.environ["FIFTYONE_DATABASE_URI"] = MONGO_URI
+    os.environ["FIFTYONE_DATABASE_NAME"] = DATABASE_NAME
+    import fiftyone as fo
+
+    fo.config.database_uri = MONGO_URI
+    fo.config.database_name = DATABASE_NAME
+
+
+def _is_excluded_field(name: str, field) -> bool:
+    lower = name.lower()
+    if any(part in lower for part in EXCLUDE_NAME_PARTS):
+        return True
+    # Drop VectorField / ArrayField-style embedding storage by type name.
+    type_name = type(field).__name__.lower()
+    if "vector" in type_name:
+        return True
+    return False
+
+
+def _csv_fields(dataset) -> list[str]:
+    schema = dataset.get_field_schema()
+    return [name for name, field in schema.items() if not _is_excluded_field(name, field)]
+
+
+def _verified_view(sample_collection):
+    """Return a view restricted to samples where `verified` is True.
+
+    Samples missing the `verified` field, or with it set to False/None, are
+    excluded. Requires the `verified` field to exist on the dataset schema.
+    """
+    from fiftyone import ViewField as F
+
+    schema = sample_collection.get_field_schema()
+    if "verified" not in schema:
+        print(
+            "WARNING: dataset has no `verified` field; --verified-only has no effect.",
+            file=sys.stderr,
+        )
+        return sample_collection
+    return sample_collection.match(F("verified") == True)  # noqa: E712
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Export FiftyOne dataset to CSV (no images, no embeddings)."
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=DEFAULT_OUT,
+        help=f"Output CSV path (default: {DEFAULT_OUT})",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List datasets in the database and exit (sanity check).",
+    )
+    parser.add_argument(
+        "--verified-only",
+        action="store_true",
+        help=(
+            "Exclude samples that are not marked verified=True. "
+            "Samples missing the `verified` field are treated as unverified."
+        ),
+    )
+    args = parser.parse_args()
+
+    _configure_fiftyone()
+    import fiftyone as fo
+    import fiftyone.types as fot
+
+    print(f"Connecting: {MONGO_URI}  db={DATABASE_NAME}")
+    try:
+        names = fo.list_datasets()
+    except Exception as exc:
+        print(f"ERROR: cannot reach MongoDB / FiftyOne: {exc}", file=sys.stderr)
+        print(
+            "Check VPN/network access to maximilian.shore.mbari.org:27017.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.list:
+        print(f"Datasets ({len(names)}):")
+        for n in sorted(names):
+            print(f"  {n}")
+        return 0
+
+    if DATASET_NAME not in names:
+        print(f"ERROR: dataset {DATASET_NAME!r} not found.", file=sys.stderr)
+        print("Available:", file=sys.stderr)
+        for n in sorted(names):
+            print(f"  {n}", file=sys.stderr)
+        return 1
+
+    dataset = fo.load_dataset(DATASET_NAME)
+    fields = _csv_fields(dataset)
+    out = args.output.expanduser().resolve()
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    total_samples = len(dataset)
+    view = dataset.view()
+    if args.verified_only:
+        view = _verified_view(view)
+        print(
+            f"Filtering to verified samples: {len(view)}/{total_samples} "
+            f"({total_samples - len(view)} unverified excluded)"
+        )
+
+    print(f"Dataset: {DATASET_NAME}  samples={len(view)}")
+    print(f"CSV fields ({len(fields)}): {', '.join(fields)}")
+    print(f"Writing: {out}")
+
+    view.export(
+        dataset_type=fot.CSVDataset,
+        labels_path=str(out),
+        fields=fields,
+        export_media=False,
+    )
+    print(f"Done: {out} ({out.stat().st_size} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/set_verified.py
+++ b/scripts/set_verified.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# fiftyone-sync, Apache-2.0 license
+# Filename: scripts/set_verified.py
+# Description: Add a boolean `verified`=True to every sample in specific FiftyOne Enterprise datasets. Requires an API key in the FIFTYONE_API_KEY environment variable.
+# required for syncing with fiftyone-sync service
+"""
+Set a `verified` boolean to True on every sample in the target datasets.
+
+Connects to the FiftyOne Enterprise (professional) deployment at
+https://mbari.fiftyone.ai. Requires an API key in the FIFTYONE_API_KEY
+environment variable.
+"""
+
+
+import fiftyone as fo
+
+DATASETS = [
+    "ptvr_hm_verified_dataset",
+    "902004-Planktivore_v78_5151_pd",
+    "902004-Planktivore_v43_5151",
+    "902004-Planktivore_v66_5151",
+    "902004-Planktivore_v21_5151",
+    "902004-Planktivore_v43_5151",
+]
+
+
+def main() -> None:
+    for name in DATASETS:
+        dataset = fo.load_dataset(name)
+        if "verified" not in dataset.get_field_schema():
+            dataset.add_sample_field("verified", fo.BooleanField)
+        dataset.set_values("verified", [True] * len(dataset))
+        dataset.save()
+        print(f"{name}: set verified=True on {len(dataset)} samples")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/launcher_template.py
+++ b/src/app/launcher_template.py
@@ -118,6 +118,9 @@ LAUNCHER_TEMPLATE = r"""
               <label class="force-sync-option" title="Re-fetch media and localizations from Tator instead of using cached data when available.">
                 <input type="checkbox" id="force-sync-checkbox" name="force_sync" value="1"> Force sync
               </label>
+              <label class="force-sync-option" title="Only include localizations whose verified attribute is set to true in the built dataset.">
+                <input type="checkbox" id="verified-only-checkbox" name="verified_only" value="1"> Verified only
+              </label>
               <span id="sync-status" class="sync-status" aria-live="polite"></span>
               <a id="fiftyone-app-link" href="#" target="_blank" rel="noopener" class="fiftyone-app-link" style="display: none;">Open Voxel51</a>
             </div>
@@ -706,6 +709,10 @@ LAUNCHER_TEMPLATE = r"""
             params.set('force_sync', 'true');
             params.set('force_embeddings', 'true');
             params.set('force_umap', 'true');
+          }
+          var verifiedOnlyEl = document.getElementById('verified-only-checkbox');
+          if (verifiedOnlyEl && verifiedOnlyEl.checked) {
+            params.set('verified_only', 'true');
           }
           if (isEnterprise) {
             var s3BucketEl = document.getElementById('s3-bucket-input');

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -564,6 +564,10 @@ async def sync(
     s3_prefix: str | None = Query(
         None, description="Optional S3 prefix (folder) for crop image upload"
     ),
+    verified_only: bool = Query(
+        False,
+        description="Only include localizations whose `verified` attribute is truthy in the built dataset",
+    ),
 ) -> dict:
     """
     Trigger sync: enqueues a job to fetch Tator media + localizations, build FiftyOne dataset, launch App.
@@ -628,6 +632,7 @@ async def sync(
             section_id=section_id,
             query=query,
             localization_type_id=localization_type_id,
+            verified_only=verified_only,
         )
         return {"job_id": job_id, "status": "queued", "port": port}
     except Exception as e:

--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -2951,6 +2951,7 @@ def _create_sample_from_loc(
     s3_bucket: str | None = None,
     s3_prefix: str | None = None,
     media_attributes_map: dict[int, dict[str, Any]] | None = None,
+    verified_only: bool = False,
 ) -> fo.Sample | None:
     """Create a FiftyOne sample from a localization (for reconcile add-new)."""
     elemental_id = loc.get("elemental_id") or loc.get("id")
@@ -2959,6 +2960,8 @@ def _create_sample_from_loc(
     elemental_id = str(elemental_id)
     label = _get_label_from_loc(loc)
     if include_classes and label not in include_classes:
+        return None
+    if verified_only and not _loc_is_verified(loc):
         return None
     filepath = _crop_filepath_for_sample(
         media_stem, elemental_id, crops_dir, s3_bucket=s3_bucket, s3_prefix=s3_prefix
@@ -3106,6 +3109,7 @@ def reconcile_dataset_with_tator(
 
     tator_eids = set(loc_index.keys())
     include_classes = set(config.get("include_classes") or [])
+    verified_only = bool(config.get("verified_only"))
 
     # Optimize media_id_to_stem creation - compute once and reuse
     media_id_to_stem = None
@@ -3272,6 +3276,7 @@ def reconcile_dataset_with_tator(
                 s3_bucket=s3_bucket,
                 s3_prefix=s3_prefix,
                 media_attributes_map=media_attributes_map,
+                verified_only=verified_only,
             )
 
             if sample:
@@ -3302,6 +3307,18 @@ def _get_label_from_loc(loc: dict) -> str:
     return "Unknown"
 
 
+def _loc_is_verified(loc: dict | None) -> bool:
+    """True if the localization's `verified` attribute is truthy.
+
+    Missing localizations or a missing/False/None `verified` attribute are
+    treated as unverified (used by the verified_only sync/UI filter).
+    """
+    if not loc:
+        return False
+    attrs = loc.get("attributes") or {}
+    return bool(attrs.get("verified"))
+
+
 def build_fiftyone_dataset_from_crops(
     crops_dir: str,
     localizations_jsonl_path: str,
@@ -3317,6 +3334,8 @@ def build_fiftyone_dataset_from_crops(
 
     Config keys (optional):
         include_classes: list of labels to include (None = all)
+        verified_only: bool; when True, only include localizations whose
+            `verified` attribute is truthy (missing/False/no-loc = excluded)
         image_extensions: glob patterns (default: ["*.png", "*.jpg", ...])
         max_samples: max samples to load (None = no limit)
 
@@ -3324,6 +3343,7 @@ def build_fiftyone_dataset_from_crops(
     """
     config = config or {}
     include_classes = set(config.get("include_classes") or [])
+    verified_only = bool(config.get("verified_only"))
     image_extensions = config.get("image_extensions") or [
         "*.png",
         "*.jpg",
@@ -3361,6 +3381,8 @@ def build_fiftyone_dataset_from_crops(
             label = _get_label_from_loc(loc) if loc else (media_stem or "Unknown")
 
             if include_classes and label not in include_classes:
+                continue
+            if verified_only and not _loc_is_verified(loc):
                 continue
 
             sample_filepath = _crop_filepath_for_sample(
@@ -4278,6 +4300,7 @@ def run_sync_job(
     section_id: int | None = None,
     query: str | None = None,
     localization_type_id: int | None = None,
+    verified_only: bool = False,
 ) -> dict[str, Any]:
     """
     Entrypoint for RQ worker: all args are serializable. Calls sync_project_to_fiftyone.
@@ -4288,7 +4311,7 @@ def run_sync_job(
     logger.info(
         f"run_sync_job received project_id={project_id} version_id={version_id} "
         f"section_id={section_id} query={'set' if (query or '').strip() else 'none'} "
-        f"localization_type_id={localization_type_id}"
+        f"localization_type_id={localization_type_id} verified_only={verified_only}"
     )
 
     job_meta_handler: logging.Handler | None = None
@@ -4321,6 +4344,7 @@ def run_sync_job(
             section_id=section_id,
             query=query,
             localization_type_id=localization_type_id,
+            verified_only=verified_only,
         )
     finally:
         if job_meta_handler is not None:
@@ -4650,6 +4674,7 @@ def sync_project_to_fiftyone(
     section_id: int | None = None,
     query: str | None = None,
     localization_type_id: int | None = None,
+    verified_only: bool = False,
 ) -> dict[str, Any]:
     """
     Fetch Tator media and localizations, build FiftyOne dataset, launch App on given port.
@@ -4675,7 +4700,7 @@ def sync_project_to_fiftyone(
     logger.info(
         f"sync_project_to_fiftyone CALLED: project_id={project_id} version_id={version_id} "
         f"section_id={section_id} query={'set' if (query or '').strip() else 'none'} "
-        f"api_url={api_url} port={port} s3_bucket={s3_bucket or 'none'}"
+        f"api_url={api_url} port={port} s3_bucket={s3_bucket or 'none'} verified_only={verified_only}"
     )
     resolved_db = (
         database_name.strip() if database_name and database_name.strip() else None
@@ -4810,6 +4835,7 @@ def sync_project_to_fiftyone(
         config["project_id"] = project_id
         config["version_id"] = version_id
         config["force_sync"] = force_sync
+        config["verified_only"] = verified_only
         # In enterprise/production, use S3 URIs for sample filepaths so FiftyOne loads from S3
         if s3_bucket:
             config["s3_bucket"] = s3_bucket

--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -3096,6 +3096,7 @@ def reconcile_dataset_with_tator(
     """
     Reconcile existing dataset with current Tator localizations:
     - Remove samples whose elemental_id was deleted in Tator
+    - Remove samples that are no longer verified, when config["verified_only"] is set
     - Update samples whose modified_datetime changed (crop file already overwritten)
     - Add samples for new elemental_ids in Tator
     """
@@ -3118,19 +3119,28 @@ def reconcile_dataset_with_tator(
     if not media_id_to_stem:
         media_id_to_stem = _media_id_to_stem_from_crops(crops_dir)
 
-    # 1. Remove samples deleted in Tator (only when we have a non-empty localization set from Tator)
+    # 1. Remove samples deleted in Tator (only when we have a non-empty localization set from Tator),
+    # and (when verified_only) samples that are still in Tator but no longer verified.
     # values() with a single field returns a flat list; calling it twice and zipping avoids the
     # multi-field return format (which yields one list-per-field, not one tuple-per-sample).
     logger.info("Reconcile: Remove samples deleted in Tator")
     all_sample_ids = dataset.values("id", _enforce_natural_order=False)
     all_eids = dataset.values("elemental_id", _enforce_natural_order=False)
     to_remove: list[str] = []
+    to_remove_unverified: list[str] = []
     dataset_eids: set[str] = set()
     for sample_id, eid in zip(all_sample_ids, all_eids):
         if eid is not None:
             eid_str = str(eid)
             if eid_str in tator_eids:
-                dataset_eids.add(eid_str)
+                if verified_only and not _loc_is_verified(loc_index.get(eid_str)):
+                    # Still exists in Tator but no longer verified; drop from the
+                    # verified_only dataset. Not added to dataset_eids, so step 3
+                    # ("add new") will consider re-adding it, but _create_sample_from_loc
+                    # will skip it again since it remains unverified.
+                    to_remove_unverified.append(sample_id)
+                else:
+                    dataset_eids.add(eid_str)
             elif tator_eids:
                 to_remove.append(sample_id)
 
@@ -3144,6 +3154,13 @@ def reconcile_dataset_with_tator(
     else:
         logger.info(
             "Reconcile: 0 localizations from Tator; skipping delete step (keeping existing samples)"
+        )
+
+    if to_remove_unverified:
+        dataset.delete_samples(to_remove_unverified)
+        logger.info(
+            f"Reconcile: removed {len(to_remove_unverified)} samples "
+            "(no longer verified; verified_only enabled)"
         )
 
     # 2. Update samples with changed modified_datetime (crop already overwritten by crop_localizations_parallel)

--- a/src/app/sync_queue.py
+++ b/src/app/sync_queue.py
@@ -65,12 +65,14 @@ def enqueue_sync(
     section_id: int | None = None,
     query: str | None = None,
     localization_type_id: int | None = None,
+    verified_only: bool = False,
 ) -> str:
     """
     Enqueue a sync job. Returns RQ job id. Requires Redis.
     project_name is used by the worker to resolve get_database_uri(project_id, port).
     vss_project_key is used to select a specific VSS project configuration for embeddings.
     localization_type_id restricts the sync to a single Tator box (localization) type.
+    verified_only restricts the built dataset to localizations with a truthy `verified` attribute.
     """
     from rq import Queue
 
@@ -93,6 +95,7 @@ def enqueue_sync(
         section_id=section_id,
         query=query,
         localization_type_id=localization_type_id,
+        verified_only=verified_only,
         job_timeout=3600 * 24,  # 24h for large projects
         result_ttl=3600 * 24,
         failure_ttl=3600,

--- a/tests/test_export_dataset_csv.py
+++ b/tests/test_export_dataset_csv.py
@@ -1,0 +1,67 @@
+# fiftyone-sync, Apache-2.0 license
+# Filename: tests/test_export_dataset_csv.py
+# Description: Unit tests for the verified-only filter in scripts/export_dataset_csv.py.
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import fiftyone as fo
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "export_dataset_csv.py"
+
+
+def _load_export_module():
+    spec = importlib.util.spec_from_file_location("export_dataset_csv", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def export_mod():
+    return _load_export_module()
+
+
+@pytest.fixture
+def dataset():
+    ds = fo.Dataset()
+    yield ds
+    ds.delete()
+
+
+def test_verified_view_keeps_only_verified_true(export_mod, dataset):
+    dataset.add_sample_field("verified", fo.BooleanField)
+    dataset.add_samples(
+        [
+            fo.Sample(filepath="/tmp/a.jpg", verified=True),
+            fo.Sample(filepath="/tmp/b.jpg", verified=False),
+            fo.Sample(filepath="/tmp/c.jpg"),  # verified not set (None)
+        ]
+    )
+
+    view = export_mod._verified_view(dataset.view())
+
+    assert len(view) == 1
+    assert view.first().filepath == "/tmp/a.jpg"
+
+
+def test_verified_view_noop_when_field_missing(export_mod, dataset, capsys):
+    dataset.add_samples([fo.Sample(filepath="/tmp/a.jpg")])
+
+    view = export_mod._verified_view(dataset.view())
+
+    assert len(view) == len(dataset)
+    assert "no `verified` field" in capsys.readouterr().err
+
+
+def test_csv_fields_excludes_filepath_and_embeddings(export_mod, dataset):
+    dataset.add_sample_field("embedding", fo.VectorField)
+    dataset.add_samples([fo.Sample(filepath="/tmp/a.jpg", embedding=[0.1, 0.2])])
+
+    fields = export_mod._csv_fields(dataset)
+
+    assert "filepath" not in fields
+    assert "embedding" not in fields
+    assert "id" in fields

--- a/tests/test_verified_only_filter.py
+++ b/tests/test_verified_only_filter.py
@@ -1,0 +1,129 @@
+# fiftyone-sync, Apache-2.0 license
+# Filename: tests/test_verified_only_filter.py
+# Description: Tests for the verified_only sync/UI filter (excludes non-verified localizations).
+
+import src.app.sync as sync
+
+
+def _make_loc(attrs, elemental_id="eid-1", media=1):
+    return {
+        "elemental_id": elemental_id,
+        "media": media,
+        "attributes": attrs,
+        "modified_datetime": None,
+        "created_datetime": None,
+    }
+
+
+def test_loc_is_verified_true_when_attribute_true():
+    loc = _make_loc({"verified": True})
+    assert sync._loc_is_verified(loc) is True
+
+
+def test_loc_is_verified_false_when_attribute_false():
+    loc = _make_loc({"verified": False})
+    assert sync._loc_is_verified(loc) is False
+
+
+def test_loc_is_verified_false_when_attribute_missing():
+    loc = _make_loc({"Label": "Krill"})
+    assert sync._loc_is_verified(loc) is False
+
+
+def test_loc_is_verified_false_when_loc_is_none():
+    assert sync._loc_is_verified(None) is False
+
+
+def test_create_sample_from_loc_verified_only_excludes_unverified():
+    loc = _make_loc({"Label": "Krill", "verified": False})
+    sample = sync._create_sample_from_loc(
+        loc,
+        crops_dir="/tmp/crops",
+        media_stem="media1",
+        include_classes=set(),
+        s3_bucket="test-bucket",  # bypasses local filesystem existence check
+        verified_only=True,
+    )
+    assert sample is None
+
+
+def test_create_sample_from_loc_verified_only_excludes_missing_attribute():
+    loc = _make_loc({"Label": "Krill"})
+    sample = sync._create_sample_from_loc(
+        loc,
+        crops_dir="/tmp/crops",
+        media_stem="media1",
+        include_classes=set(),
+        s3_bucket="test-bucket",
+        verified_only=True,
+    )
+    assert sample is None
+
+
+def test_create_sample_from_loc_verified_only_includes_verified():
+    loc = _make_loc({"Label": "Krill", "verified": True})
+    sample = sync._create_sample_from_loc(
+        loc,
+        crops_dir="/tmp/crops",
+        media_stem="media1",
+        include_classes=set(),
+        s3_bucket="test-bucket",
+        verified_only=True,
+    )
+    assert sample is not None
+    assert sample["elemental_id"] == "eid-1"
+
+
+def test_create_sample_from_loc_default_includes_unverified():
+    """verified_only defaults to False: unverified localizations are still included."""
+    loc = _make_loc({"Label": "Krill", "verified": False})
+    sample = sync._create_sample_from_loc(
+        loc,
+        crops_dir="/tmp/crops",
+        media_stem="media1",
+        include_classes=set(),
+        s3_bucket="test-bucket",
+    )
+    assert sample is not None
+
+
+def test_reconcile_forwards_verified_only_to_create_sample_from_loc(monkeypatch):
+    """config['verified_only'] set by sync_project_to_fiftyone must reach _create_sample_from_loc."""
+    captured_kwargs = {}
+
+    def _fake_create_sample_from_loc(loc, crops_dir, media_stem, include_classes, **kwargs):
+        captured_kwargs.update(kwargs)
+        return None
+
+    monkeypatch.setattr(sync, "_create_sample_from_loc", _fake_create_sample_from_loc)
+    monkeypatch.setattr(sync, "repair_undeclared_sample_fields", lambda *a, **k: None)
+    monkeypatch.setattr(sync, "_media_id_to_stem_from_crops", lambda *_a, **_k: {1: "media1"})
+
+    class _FakeDataset:
+        def values(self, field, **kwargs):
+            return []
+
+        def iter_samples(self, **kwargs):
+            return []
+
+        def delete_samples(self, ids):
+            pass
+
+        def add_samples(self, samples):
+            pass
+
+        def __len__(self):
+            return 0
+
+    loc_index = {"eid-1": _make_loc({"Label": "Krill", "verified": False}, media=1)}
+
+    sync.reconcile_dataset_with_tator(
+        dataset=_FakeDataset(),
+        loc_index=loc_index,
+        crops_dir="/tmp/crops",
+        download_dir=None,
+        config={"verified_only": True},
+        max_samples=None,
+    )
+
+    assert captured_kwargs.get("verified_only") is True

--- a/tests/test_verified_only_filter.py
+++ b/tests/test_verified_only_filter.py
@@ -127,3 +127,120 @@ def test_reconcile_forwards_verified_only_to_create_sample_from_loc(monkeypatch)
     )
 
     assert captured_kwargs.get("verified_only") is True
+
+
+class _FakeSample:
+    """Minimal fo.Sample stand-in for reconcile's remove/update passes."""
+
+    def __init__(self, sample_id, elemental_id):
+        self.id = sample_id
+        self.elemental_id = elemental_id
+
+    def has_field(self, _name):
+        return False
+
+    def __contains__(self, _key):
+        return False
+
+    def save(self):
+        pass
+
+
+class _FakeReconcileDataset:
+    """Minimal fo.Dataset stand-in that tracks delete_samples/add_samples calls."""
+
+    def __init__(self, samples):
+        self._samples = list(samples)
+        self.deleted_ids: list[str] = []
+        self.added: list = []
+
+    def values(self, field, **_kwargs):
+        if field == "id":
+            return [s.id for s in self._samples]
+        if field == "elemental_id":
+            return [s.elemental_id for s in self._samples]
+        return []
+
+    def iter_samples(self, **_kwargs):
+        return list(self._samples)
+
+    def delete_samples(self, ids):
+        self.deleted_ids.extend(ids)
+        self._samples = [s for s in self._samples if s.id not in ids]
+
+    def add_samples(self, samples):
+        self.added.extend(samples)
+
+    def __len__(self):
+        return len(self._samples)
+
+
+def test_reconcile_removes_samples_that_became_unverified(monkeypatch):
+    """
+    A sample still present in Tator (not deleted) but whose `verified` attribute
+    flipped to False must be removed when verified_only is enabled, and must not
+    be re-added by the "add new samples" step (since it's still unverified).
+    """
+    monkeypatch.setattr(sync, "repair_undeclared_sample_fields", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sync, "_media_id_to_stem_from_crops", lambda *_a, **_k: {1: "media1", 2: "media2"}
+    )
+    monkeypatch.setattr(sync, "_apply_loc_to_sample", lambda *a, **k: None)
+
+    keep_sample = _FakeSample("sample-keep", "keep-verified")
+    drop_sample = _FakeSample("sample-drop", "drop-unverified")
+    dataset = _FakeReconcileDataset([keep_sample, drop_sample])
+
+    loc_index = {
+        "keep-verified": _make_loc(
+            {"Label": "A", "verified": True}, elemental_id="keep-verified", media=1
+        ),
+        "drop-unverified": _make_loc(
+            {"Label": "B", "verified": False}, elemental_id="drop-unverified", media=2
+        ),
+    }
+
+    sync.reconcile_dataset_with_tator(
+        dataset=dataset,
+        loc_index=loc_index,
+        crops_dir="/tmp/crops",
+        download_dir=None,
+        config={"verified_only": True, "s3_bucket": "test-bucket"},
+        max_samples=None,
+    )
+
+    assert dataset.deleted_ids == ["sample-drop"]
+    assert dataset.added == []
+
+
+def test_reconcile_keeps_unverified_samples_when_verified_only_disabled(monkeypatch):
+    """Default behavior (verified_only=False) must not remove unverified samples."""
+    monkeypatch.setattr(sync, "repair_undeclared_sample_fields", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sync, "_media_id_to_stem_from_crops", lambda *_a, **_k: {1: "media1", 2: "media2"}
+    )
+    monkeypatch.setattr(sync, "_apply_loc_to_sample", lambda *a, **k: None)
+
+    keep_sample = _FakeSample("sample-keep", "keep-verified")
+    unverified_sample = _FakeSample("sample-unverified", "still-unverified")
+    dataset = _FakeReconcileDataset([keep_sample, unverified_sample])
+
+    loc_index = {
+        "keep-verified": _make_loc(
+            {"Label": "A", "verified": True}, elemental_id="keep-verified", media=1
+        ),
+        "still-unverified": _make_loc(
+            {"Label": "B", "verified": False}, elemental_id="still-unverified", media=2
+        ),
+    }
+
+    sync.reconcile_dataset_with_tator(
+        dataset=dataset,
+        loc_index=loc_index,
+        crops_dir="/tmp/crops",
+        download_dir=None,
+        config={},
+        max_samples=None,
+    )
+
+    assert dataset.deleted_ids == []


### PR DESCRIPTION
## Summary

Adds a `--verified-only` flag to `scripts/export_dataset_csv.py` so unverified
samples can be excluded when exporting a dataset to CSV.

- Samples missing the `verified` field, or with it set to `False`, are excluded.
- If the dataset has no `verified` field at all, the flag is a no-op with a warning.
- Also adds `scripts/set_verified.py` (previously untracked) which is the
  companion script that sets `verified=True` on samples.

## Closes

Closes #29

## Testing

- Added `tests/test_export_dataset_csv.py` covering the filter and CSV field
  exclusion logic against a real in-memory FiftyOne dataset.
- Full suite: `95 passed` (`pytest tests/`).

## Docs

- Added a "Scripts" section to `README.md` documenting both scripts and the
  new flag.