### PR TITLE
perf(app): parallelize image media download+crop in sequential sync path

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,10 +357,14 @@ If embeddings were removed only from the schema (or cleared incompletely in Mong
 - Crops: `/tmp/fiftyone_sync_project_{id}/crops/{media_stem}/{elemental_id}.png`
 
 Image media are downloaded and cropped **concurrently** (thread pool); video
-media are still downloaded and cropped **one at a time** so large source videos
-do not accumulate on local disk. Existing non-empty crop files are reused even
-when the crop manifest is missing or stale; localizations are recropped when
-their recorded modification time changes.
+media are still downloaded and cropped **one at a time**. Either way, each
+downloaded source file (image or video) is deleted immediately after its own
+crop completes, so downloaded media never accumulates beyond
+`MEDIA_DOWNLOAD_WORKERS` files (images) or 1 file (videos) at a time on local
+disk — FiftyOne samples are always built from the crops directory, never from
+the raw downloaded file. Existing non-empty crop files are reused even when the
+crop manifest is missing or stale; localizations are recropped when their
+recorded modification time changes.
 
 Labels come from `attributes.Label` (or `attributes.label`) in localizations.
 

--- a/README.md
+++ b/README.md
@@ -356,12 +356,24 @@ If embeddings were removed only from the schema (or cleared incompletely in Mong
 - Localizations: `/tmp/fiftyone_sync_project_{id}/localizations.jsonl` (JSONL)
 - Crops: `/tmp/fiftyone_sync_project_{id}/crops/{media_stem}/{elemental_id}.png`
 
-Media are downloaded and cropped one at a time so large source videos do not
-accumulate on local disk. Existing non-empty crop files are reused even when the
-crop manifest is missing or stale; localizations are recropped when their recorded
-modification time changes.
+Image media are downloaded and cropped **concurrently** (thread pool); video
+media are still downloaded and cropped **one at a time** so large source videos
+do not accumulate on local disk. Existing non-empty crop files are reused even
+when the crop manifest is missing or stale; localizations are recropped when
+their recorded modification time changes.
 
 Labels come from `attributes.Label` (or `attributes.label`) in localizations.
+
+**Crop/download tuning** (set on the sync service; restart to apply):
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `MEDIA_DOWNLOAD_WORKERS` | `8` | Number of image media downloaded + cropped concurrently in the "one media at a time" sync path. Videos always process one at a time regardless of this setting. |
+| `CROP_FRAME_BATCH_SIZE` | `20` | Number of image crop tasks batched per `ThreadPoolExecutor` cycle inside `crop_localizations_parallel`, and number of video frames extracted per ffmpeg invocation. |
+| `CROP_VIDEO_WORKERS` | `8` | Max concurrent workers used to crop frames extracted from a single video. |
+| `CROP_TIMEOUT` | `300` | Timeout (seconds) for ffmpeg frame-extraction batches. |
+
+If downloads from Tator are slow (network-bound), raising `MEDIA_DOWNLOAD_WORKERS` has the biggest effect on wall-clock time for image-heavy projects; `CROP_FRAME_BATCH_SIZE` only matters for bulk/recompute crop paths that hand many media to `crop_localizations_parallel` at once.
 
 ### Sync edits back to Tator
 

--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -1712,6 +1712,22 @@ def _media_locs_already_cropped(
     return True
 
 
+def _cleanup_downloaded_image(download_dir: str, media_id: int, media_name: str) -> None:
+    """Remove a single downloaded image file to reclaim space as soon as its crop is done.
+
+    Mirrors _cleanup_downloaded_videos but scoped to one media's file, since images
+    are downloaded/cropped concurrently (many at once) rather than one at a time.
+    """
+    if not download_dir or not media_name:
+        return
+    path = os.path.join(download_dir, f"{media_id}_{media_name}")
+    try:
+        if os.path.isfile(path):
+            os.unlink(path)
+    except OSError:
+        pass
+
+
 def _download_and_crop_one_media(
     api: Any,
     project_id: int,
@@ -1723,7 +1739,8 @@ def _download_and_crop_one_media(
     dl_dir: str,
     size: int,
 ) -> tuple[int, Any | None, int, int]:
-    """Download (if resolved) and crop a single media's localizations.
+    """Download (if resolved), crop, and immediately delete a single media's
+    downloaded file to reclaim disk space.
 
     Runs on a worker thread from the image download pool in
     _download_and_crop_media_sequentially. Returns (mid, media_obj, num_ok, num_fail).
@@ -1738,6 +1755,14 @@ def _download_and_crop_one_media(
         locs_to_crop=locs_for_media,
         media_objects=[media_obj] if media_obj is not None else [],
     )
+    if media_obj is not None:
+        # Delete now (mirroring the video path below) so at most
+        # MEDIA_DOWNLOAD_WORKERS downloaded images occupy local disk at once,
+        # instead of every image accumulating until the whole-sync cleanup.
+        # FiftyOne samples are always built from crops_dir, never from this
+        # raw downloaded file, so it's safe to remove as soon as its crop(s)
+        # are written.
+        _cleanup_downloaded_image(dl_dir, mid, getattr(media_obj, "name", "") or "")
     return mid, media_obj, ok, fail
 
 
@@ -1760,10 +1785,13 @@ def _download_and_crop_media_sequentially(
     Videos are excluded from the concurrent pool because large videos (several
     GB each) sitting on local disk simultaneously would blow out disk usage;
     interleaving download/crop/delete per video keeps at most one video file
-    on local disk at a time. Images have no such disk-usage concern, and for
-    image-heavy projects the per-media network round-trip (one HTTP download
-    per media) -- not crop CPU work -- is the actual bottleneck, so images are
-    fanned out across a thread pool instead of processed one at a time.
+    on local disk at a time. For image-heavy projects the per-media network
+    round-trip (one HTTP download per media) -- not crop CPU work -- is the
+    actual bottleneck, so images are fanned out across a thread pool instead
+    of processed one at a time; each image is still deleted immediately after
+    its own crop completes (mirroring the video cleanup), so at most
+    MEDIA_DOWNLOAD_WORKERS downloaded images occupy local disk at once instead
+    of every image accumulating until the whole-sync cleanup.
 
     Returns (download_dir, processed_media_objects, num_cropped, num_failed).
     """
@@ -1864,9 +1892,8 @@ def _download_and_crop_media_sequentially(
             num_fail += fail
             processed_media.append(media_obj)
             # Delete the video immediately so at most one large video occupies
-            # local disk at a time; images are left in place (existing behavior)
-            # until the final download-dir cleanup, since they're small and some
-            # sample types reference the downloaded image directly.
+            # local disk at a time. Images are cleaned up the same way, right
+            # after their own crop completes (see _download_and_crop_one_media).
             _cleanup_downloaded_videos(dl_dir)
 
     return dl_dir, processed_media, num_ok, num_fail

--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -748,6 +748,10 @@ def _ffprobe_dimensions(input_path_or_url: str | Path, _cache: dict[str, tuple[i
 _DEFAULT_CROP_TIMEOUT = int(os.environ.get("CROP_TIMEOUT", "300"))
 _DEFAULT_VIDEO_WORKERS = int(os.environ.get("CROP_VIDEO_WORKERS", "8"))
 _FRAME_BATCH_SIZE = int(os.environ.get("CROP_FRAME_BATCH_SIZE", "20"))
+# Number of image media downloaded + cropped concurrently in
+# _download_and_crop_media_sequentially. Videos are excluded from this pool and
+# always processed one at a time (see that function's docstring).
+_MEDIA_DOWNLOAD_WORKERS = int(os.environ.get("MEDIA_DOWNLOAD_WORKERS", "8"))
 
 _PIL_RESAMPLE = Image.LANCZOS
 
@@ -1708,6 +1712,35 @@ def _media_locs_already_cropped(
     return True
 
 
+def _download_and_crop_one_media(
+    api: Any,
+    project_id: int,
+    mid: int,
+    media_obj: Any | None,
+    locs_for_media: list[dict],
+    localizations_path: str,
+    crops_dir: str,
+    dl_dir: str,
+    size: int,
+) -> tuple[int, Any | None, int, int]:
+    """Download (if resolved) and crop a single media's localizations.
+
+    Runs on a worker thread from the image download pool in
+    _download_and_crop_media_sequentially. Returns (mid, media_obj, num_ok, num_fail).
+    """
+    if media_obj is not None:
+        save_media_to_tmp(api, project_id, [media_obj], media_ids_filter={mid})
+    ok, fail = crop_localizations_parallel(
+        dl_dir,
+        localizations_path,
+        crops_dir,
+        size=size,
+        locs_to_crop=locs_for_media,
+        media_objects=[media_obj] if media_obj is not None else [],
+    )
+    return mid, media_obj, ok, fail
+
+
 def _download_and_crop_media_sequentially(
     api: Any,
     project_id: int,
@@ -1719,16 +1752,18 @@ def _download_and_crop_media_sequentially(
     size: int = 224,
 ) -> tuple[str, list[Any], int, int]:
     """
-    Download and crop one media at a time: download media N -> crop only media N's
-    localizations -> delete media N's video file (if any) -> move to media N+1.
+    Download and crop media: images are downloaded + cropped concurrently
+    (up to MEDIA_DOWNLOAD_WORKERS at a time); videos are still processed
+    strictly one at a time -- download video N -> crop only video N's
+    localizations -> delete video N's file -> move to video N+1.
 
-    Downloading every needed media before cropping any of them means the whole
-    download phase (which can take minutes per video) has to finish before
-    cropping starts on even the first one, and every downloaded video sits on
-    local disk simultaneously (large videos can be several GB each). Interleaving
-    keeps at most one media file on local disk at a time and lets cropping start
-    as soon as the first media finishes downloading instead of waiting on the
-    whole batch.
+    Videos are excluded from the concurrent pool because large videos (several
+    GB each) sitting on local disk simultaneously would blow out disk usage;
+    interleaving download/crop/delete per video keeps at most one video file
+    on local disk at a time. Images have no such disk-usage concern, and for
+    image-heavy projects the per-media network round-trip (one HTTP download
+    per media) -- not crop CPU work -- is the actual bottleneck, so images are
+    fanned out across a thread pool instead of processed one at a time.
 
     Returns (download_dir, processed_media_objects, num_cropped, num_failed).
     """
@@ -1736,8 +1771,11 @@ def _download_and_crop_media_sequentially(
     processed_media: list[Any] = []
     num_ok = 0
     num_fail = 0
-    total = len(needed_ids)
-    for idx, mid in enumerate(needed_ids, 1):
+
+    image_work: list[tuple[int, Any | None, list[dict]]] = []
+    video_work: list[tuple[int, Any, list[dict]]] = []
+
+    for mid in needed_ids:
         media_obj = media_by_id.get(mid)
         locs_for_media = locs_by_media.get(mid) or []
         if not locs_for_media:
@@ -1749,48 +1787,88 @@ def _download_and_crop_media_sequentially(
             # (potentially large) video only to discover during cropping that
             # every localization on it was already cropped.
             logger.info(
-                "Skipping download for media %s/%s (id=%s, name=%s): all %s "
+                "Skipping download for media id=%s (name=%s): all %s "
                 "crop(s) already on disk",
-                idx, total, mid, getattr(media_obj, "name", ""), len(locs_for_media),
+                mid, getattr(media_obj, "name", ""), len(locs_for_media),
             )
             processed_media.append(media_obj)
             continue
-        if media_obj is not None:
+        if media_obj is not None and _is_video_name(getattr(media_obj, "name", "") or ""):
+            video_work.append((mid, media_obj, locs_for_media))
+        else:
+            # Images, plus media ids with no Media object resolved (e.g. lookup
+            # failed) -- still attempted in case the file is already present in
+            # the download dir from an earlier run, matching the previous
+            # always-attempt-crop fallback behavior. Neither case grows local
+            # disk usage unboundedly, so both are safe to run concurrently.
+            image_work.append((mid, media_obj, locs_for_media))
+
+    if image_work:
+        workers = max(1, min(_MEDIA_DOWNLOAD_WORKERS, len(image_work)))
+        logger.info(
+            "Downloading and cropping %s image media with %s worker(s) (concurrent)...",
+            len(image_work), workers,
+        )
+        completed = 0
+        log_interval = max(1, len(image_work) // 10)
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            futures = {
+                ex.submit(
+                    _download_and_crop_one_media,
+                    api, project_id, mid, media_obj, locs_for_media,
+                    localizations_path, crops_dir, dl_dir, size,
+                ): mid
+                for mid, media_obj, locs_for_media in image_work
+            }
+            for fut in as_completed(futures):
+                completed += 1
+                try:
+                    mid, media_obj, ok, fail = fut.result()
+                except Exception as e:
+                    num_fail += 1
+                    logger.warning(
+                        "Image download/crop failed for id=%s: %s", futures[fut], e
+                    )
+                else:
+                    num_ok += ok
+                    num_fail += fail
+                    if media_obj is not None:
+                        processed_media.append(media_obj)
+                if completed % log_interval == 0 or completed == len(image_work):
+                    logger.info(
+                        "Image download/crop progress: %s/%s", completed, len(image_work)
+                    )
+
+    if video_work:
+        logger.info(
+            "Downloading and cropping %s video media one at a time...",
+            len(video_work),
+        )
+        for idx, (mid, media_obj, locs_for_media) in enumerate(video_work, 1):
             logger.info(
                 "Downloading media %s/%s (id=%s, name=%s)...",
-                idx, total, mid, getattr(media_obj, "name", ""),
+                idx, len(video_work), mid, getattr(media_obj, "name", ""),
             )
             dl_dir = save_media_to_tmp(
                 api, project_id, [media_obj], media_ids_filter={mid}
             )
-        else:
-            # No Media metadata resolved for this id (e.g. lookup failed) -- still
-            # attempt the crop in case the file is already present in the
-            # download dir from an earlier run, matching the previous
-            # always-attempt-crop behavior instead of silently dropping it.
-            logger.info(
-                "No Media object resolved for id=%s (%s/%s); attempting crop from "
-                "existing download dir",
-                mid, idx, total,
+            ok, fail = crop_localizations_parallel(
+                dl_dir,
+                localizations_path,
+                crops_dir,
+                size=size,
+                locs_to_crop=locs_for_media,
+                media_objects=[media_obj],
             )
-        ok, fail = crop_localizations_parallel(
-            dl_dir,
-            localizations_path,
-            crops_dir,
-            size=size,
-            locs_to_crop=locs_for_media,
-            media_objects=[media_obj] if media_obj is not None else [],
-        )
-        num_ok += ok
-        num_fail += fail
-        if media_obj is not None:
+            num_ok += ok
+            num_fail += fail
             processed_media.append(media_obj)
             # Delete the video immediately so at most one large video occupies
             # local disk at a time; images are left in place (existing behavior)
             # until the final download-dir cleanup, since they're small and some
             # sample types reference the downloaded image directly.
-            if _is_video_name(getattr(media_obj, "name", "") or ""):
-                _cleanup_downloaded_videos(dl_dir)
+            _cleanup_downloaded_videos(dl_dir)
+
     return dl_dir, processed_media, num_ok, num_fail
 
 

--- a/tests/test_media_download_cleanup.py
+++ b/tests/test_media_download_cleanup.py
@@ -1,0 +1,102 @@
+# fiftyone-sync, Apache-2.0 license
+# Filename: tests/test_media_download_cleanup.py
+# Description: Tests that downloaded image files are deleted immediately after cropping.
+
+from types import SimpleNamespace
+
+import src.app.sync as sync
+
+
+def _make_media(mid=101, name="frame.png"):
+    return SimpleNamespace(id=mid, name=name)
+
+
+def test_cleanup_downloaded_image_removes_existing_file(tmp_path):
+    download_dir = str(tmp_path)
+    file_path = tmp_path / "101_frame.png"
+    file_path.write_bytes(b"fake-image-bytes")
+
+    sync._cleanup_downloaded_image(download_dir, 101, "frame.png")
+
+    assert not file_path.exists()
+
+
+def test_cleanup_downloaded_image_missing_file_is_noop(tmp_path):
+    # Should not raise when the file doesn't exist.
+    sync._cleanup_downloaded_image(str(tmp_path), 999, "missing.png")
+
+
+def test_cleanup_downloaded_image_noop_without_download_dir_or_name():
+    # No exception when args are empty/falsy.
+    sync._cleanup_downloaded_image("", 1, "name.png")
+    sync._cleanup_downloaded_image("/tmp/somewhere", 1, "")
+
+
+def test_download_and_crop_one_media_deletes_downloaded_image(tmp_path, monkeypatch):
+    dl_dir = str(tmp_path)
+    media_obj = _make_media(mid=202, name="image.png")
+    downloaded_path = tmp_path / "202_image.png"
+
+    def fake_save_media_to_tmp(api, project_id, media_objects, media_ids_filter=None):
+        # Simulate the real download writing the file to disk.
+        downloaded_path.write_bytes(b"fake-image-bytes")
+        return dl_dir
+
+    def fake_crop_localizations_parallel(*args, **kwargs):
+        # Crop step runs while the downloaded file is still present.
+        assert downloaded_path.exists()
+        return (1, 0)
+
+    monkeypatch.setattr(sync, "save_media_to_tmp", fake_save_media_to_tmp)
+    monkeypatch.setattr(
+        sync, "crop_localizations_parallel", fake_crop_localizations_parallel
+    )
+
+    mid, returned_media_obj, ok, fail = sync._download_and_crop_one_media(
+        api=None,
+        project_id=1,
+        mid=202,
+        media_obj=media_obj,
+        locs_for_media=[{"elemental_id": "eid-1"}],
+        localizations_path="/tmp/does-not-matter.jsonl",
+        crops_dir=str(tmp_path / "crops"),
+        dl_dir=dl_dir,
+        size=224,
+    )
+
+    assert (mid, returned_media_obj, ok, fail) == (202, media_obj, 1, 0)
+    # Downloaded source file is gone immediately after crop, mirroring the
+    # video cleanup path.
+    assert not downloaded_path.exists()
+
+
+def test_download_and_crop_one_media_skips_cleanup_without_media_obj(
+    tmp_path, monkeypatch
+):
+    dl_dir = str(tmp_path)
+    # A pre-existing file from an earlier run that we did NOT download this
+    # time (media_obj is None) should be left alone.
+    existing_path = tmp_path / "303_old.png"
+    existing_path.write_bytes(b"already-there")
+
+    def fake_crop_localizations_parallel(*args, **kwargs):
+        return (1, 0)
+
+    monkeypatch.setattr(
+        sync, "crop_localizations_parallel", fake_crop_localizations_parallel
+    )
+
+    mid, returned_media_obj, ok, fail = sync._download_and_crop_one_media(
+        api=None,
+        project_id=1,
+        mid=303,
+        media_obj=None,
+        locs_for_media=[{"elemental_id": "eid-1"}],
+        localizations_path="/tmp/does-not-matter.jsonl",
+        crops_dir=str(tmp_path / "crops"),
+        dl_dir=dl_dir,
+        size=224,
+    )
+
+    assert (mid, returned_media_obj, ok, fail) == (303, None, 1, 0)
+    assert existing_path.exists()


### PR DESCRIPTION
## Summary

The main sync path (`_download_and_crop_media_sequentially`) downloaded and cropped media strictly **one at a time**, so the existing `CROP_FRAME_BATCH_SIZE` (default `20`) env var had no effect there — each call only ever processed a single media file. For image-heavy projects, the per-media network round-trip (one HTTP download per media) was the actual bottleneck, not crop CPU work. It also only cleaned up downloaded **video** files immediately after cropping; downloaded images accumulated on local disk for the entire sync run.

## Changes

**1. Parallelize image download + crop**
- Split `_download_and_crop_media_sequentially` into two lanes:
  - **Images** (and media ids with no resolved `Media` object): downloaded + cropped **concurrently** via a `ThreadPoolExecutor`, sized by new env var `MEDIA_DOWNLOAD_WORKERS` (default `8`).
  - **Videos**: unchanged — still processed strictly one at a time (download → crop → delete) to bound local disk usage for large video files.
- Added `_download_and_crop_one_media` helper used by the image worker pool.

**2. Delete downloaded images immediately after crop (mirrors video path)**
- Added `_cleanup_downloaded_image` and call it right after each image's crop completes, so at most `MEDIA_DOWNLOAD_WORKERS` downloaded images occupy local disk at once instead of every image accumulating until the whole-sync cleanup.
- Confirmed safe: FiftyOne samples are always built from `crops_dir` (`_create_sample_from_loc`, `_build_dataset_from_crops`), never from the raw downloaded file, and `_find_crop_cache_misses` already has a fallback (`_media_id_to_stem_from_crops`) for when the download dir is empty.
- Media ids with no resolved `Media` object this run (nothing downloaded) are left untouched, so any pre-existing file from an earlier run isn't deleted.

**3. Docs**
- Documented crop/download tuning env vars in `README.md` (`MEDIA_DOWNLOAD_WORKERS`, `CROP_FRAME_BATCH_SIZE`, `CROP_VIDEO_WORKERS`, `CROP_TIMEOUT`) and updated the "Data layout" section to describe the new concurrent-download + immediate-delete behavior.

## Testing

- `python -m pytest tests/` — 111 passed (+5 new tests in `tests/test_media_download_cleanup.py`)
- `python -c "import ast; ast.parse(open('src/app/sync.py').read())"` — syntax OK

## Tuning

If Tator downloads are slow (network-bound), raise `MEDIA_DOWNLOAD_WORKERS` (e.g. 8–16) on the sync service and restart to apply.