### PR TITLE
feat(app): push verified_only filtering into Tator media/localization queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Optional query param **`database_name`** on `GET /launch` and `POST /sync` overr
 | `section_id` | no | Tator media section ID; ANDed with `query` when both set |
 | `query` | no | Tator `encoded_search` filter (base64 Object_Search); ANDed with `section_id` when both set |
 | `localization_type_id` | no | Restrict sync to a single Tator box (localization) type |
-| `verified_only` | no | Only include localizations whose `verified` attribute is truthy in the built dataset (default: false). Exposed as the **Verified only** checkbox in the launcher applet. On subsequent syncs, samples that later become unverified are removed from the dataset (they are re-added automatically if re-verified). |
+| `verified_only` | no | Only include localizations whose `verified` attribute is truthy (default: false). Exposed as the **Verified only** checkbox in the launcher applet. When set, the Tator media (`related_attribute=verified::true`) and localization (`attribute=verified::true`) queries are filtered server-side, so unverified media/localizations are never fetched, downloaded, or cropped — this minimizes data transfer, not just what's shown in the dataset. On subsequent syncs, samples that later become unverified are removed from the dataset (they are re-added automatically if re-verified). |
 | `database_name` | no | Override MongoDB database name |
 | `config_path` | no | Path to YAML/JSON config file for dataset build |
 | `launch_app` | no | Launch FiftyOne app after sync (default: true) |

--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -332,6 +332,7 @@ def _get_localization_count_from_api(
     section_id: int | None = None,
     query: str | None = None,
     localization_type_id: int | None = None,
+    verified_only: bool = False,
 ) -> int | None:
     """
     Return total localization count from Tator API (same batching as fetch_and_save_localizations).
@@ -352,6 +353,7 @@ def _get_localization_count_from_api(
         section_id=section_id,
         query=query,
         localization_type_id=localization_type_id,
+        verified_only=verified_only,
     )
 
     try:
@@ -374,20 +376,26 @@ def fetch_project_media_ids(
     media_ids_filter: list[int] | None = None,
     version_id: int | None = None,
     section_id: int | None = None,
+    verified_only: bool = False,
 ) -> list[int]:
     """
     Fetch all media in the project. Returns list of media ids.
     If media_ids_filter is set, only those media are returned (and must exist in the project).
     If version_id is set, filters media by that version via related_attribute.
     If section_id is set, filters media to that Tator section.
+    If verified_only is set, filters media to those with at least one verified
+    localization (related_attribute=verified::true) so unverified-only media are
+    never fetched or downloaded.
     """
     logger.info(
         f"fetch_project_media_ids: project_id={project_id} filter={media_ids_filter} "
-        f"version_id={version_id} section_id={section_id}"
+        f"version_id={version_id} section_id={section_id} verified_only={verified_only}"
     )
     host = api_url.rstrip("/")
     api = tator.get_api(host, token)
-    kwargs = _media_fetch_kwargs(version_id=version_id, section_id=section_id)
+    kwargs = _media_fetch_kwargs(
+        version_id=version_id, section_id=section_id, verified_only=verified_only
+    )
     if media_ids_filter:
         # Chunk filter to avoid "Request Line is too large" from nginx (e.g. 4094 bytes).
         chunk = _MAX_SAFE_MEDIA_ID_BATCH_SIZE
@@ -1299,6 +1307,7 @@ def fetch_and_save_localizations(
     section_id: int | None = None,
     query: str | None = None,
     localization_type_id: int | None = None,
+    verified_only: bool = False,
 ) -> str:
     """
     Fetch all current localizations from Tator and write to a JSONL file.
@@ -1308,6 +1317,8 @@ def fetch_and_save_localizations(
     If media_ids is provided, only localizations for those media are fetched (required when syncing
     a subset of media; avoids empty results when project localizations are scoped to media).
     If localization_type_id is provided, only localizations of that box type are fetched.
+    If verified_only is set, only localizations whose own `verified` attribute is true are
+    fetched (attribute=verified::true), so unverified localizations are never downloaded.
 
     Batch sizes are from config (media_id_batch_size, localization_batch_size) or fallbacks to avoid
     414 Request-URI Too Large errors from nginx when the project has many media.
@@ -1353,6 +1364,7 @@ def fetch_and_save_localizations(
         section_id=section_id,
         query=query,
         localization_type_id=localization_type_id,
+        verified_only=verified_only,
     )
 
     try:
@@ -2217,9 +2229,13 @@ def _resolve_localizations_jsonl(
     section_id: int | None = None,
     query: str | None = None,
     localization_type_id: int | None = None,
+    verified_only: bool = False,
 ) -> tuple[str, list[int], bool]:
     """
     Resolve localizations JSONL and media ids for crop work.
+
+    When verified_only is True, media and localization fetches are scoped
+    server-side to verified::true so unverified data is never downloaded.
 
     Returns (localizations_path, media_ids_list, use_cached_jsonl).
     """
@@ -2247,6 +2263,7 @@ def _resolve_localizations_jsonl(
             section_id=section_id,
             query=query,
             localization_type_id=localization_type_id,
+            verified_only=verified_only,
         )
         if api_count is not None and line_count == api_count:
             use_cached_jsonl = True
@@ -2262,10 +2279,11 @@ def _resolve_localizations_jsonl(
         loc_media_ids: list[int] | None = None
         if not has_query:
             logger.info(
-                "Fetching media IDs... host=%s project_id=%s api_url=%s",
+                "Fetching media IDs... host=%s project_id=%s api_url=%s verified_only=%s",
                 api_url.rstrip("/"),
                 project_id,
                 api_url,
+                verified_only,
             )
             media_ids_list = fetch_project_media_ids(
                 api_url,
@@ -2273,6 +2291,7 @@ def _resolve_localizations_jsonl(
                 project_id,
                 version_id=version_id,
                 section_id=section_id,
+                verified_only=verified_only,
             )
             loc_media_ids = media_ids_list or None
         else:
@@ -2290,6 +2309,7 @@ def _resolve_localizations_jsonl(
             section_id=section_id,
             query=query,
             localization_type_id=localization_type_id,
+            verified_only=verified_only,
         )
         if has_query and localizations_path:
             _, media_ids_list = _localizations_jsonl_line_count_and_media_ids(
@@ -2376,11 +2396,15 @@ def _run_crop_pipeline(
     section_id: int | None = None,
     query: str | None = None,
     localization_type_id: int | None = None,
+    verified_only: bool = False,
 ) -> dict[str, Any]:
     """
     Run crop refresh pipeline and return counts/paths/context.
 
-    This function is shared by full sync and crop-recompute jobs.
+    This function is shared by full sync and crop-recompute jobs. When
+    verified_only is True, media/localization fetches are scoped server-side
+    to verified::true, so unverified media/localizations are never downloaded
+    or cropped.
     """
     dl_dir = _download_dir(project_id)
     crops = _crops_dir(
@@ -2415,6 +2439,7 @@ def _run_crop_pipeline(
             section_id=section_id,
             query=query,
             localization_type_id=localization_type_id,
+            verified_only=verified_only,
         )
         if localizations_path:
             logger.info("saved_localizations_path (JSONL): %s", localizations_path)
@@ -4801,6 +4826,7 @@ def sync_project_to_fiftyone(
                 section_id=section_id,
                 query=query,
                 localization_type_id=localization_type_id,
+                verified_only=verified_only,
             )
             if crop_result.get("status") != "ok":
                 return {
@@ -5089,6 +5115,7 @@ def main() -> None:
     localization_batch_size_cli = (
         config.get("localization_batch_size") or _DEFAULT_LOCALIZATION_BATCH_SIZE
     )
+    verified_only_cli = bool(config.get("verified_only"))
 
     # Fetch media IDs (lightweight)
     media_ids = fetch_project_media_ids(
@@ -5097,6 +5124,7 @@ def main() -> None:
         project_id,
         media_ids_filter=media_ids_filter,
         version_id=version_id,
+        verified_only=verified_only_cli,
     )
     logger.info(f"media_ids: {media_ids}")
 
@@ -5108,6 +5136,7 @@ def main() -> None:
         media_ids=media_ids if media_ids else None,
         localization_batch_size=localization_batch_size_cli,
         media_id_batch_size=media_id_batch_size_cli,
+        verified_only=verified_only_cli,
     )
     if localizations_path:
         logger.info(f"saved_localizations_path (JSONL): {localizations_path}")

--- a/src/app/sync_filters.py
+++ b/src/app/sync_filters.py
@@ -36,8 +36,14 @@ def localization_fetch_kwargs(
     section_id: int | None = None,
     query: str | None = None,
     localization_type_id: int | None = None,
+    verified_only: bool = False,
 ) -> dict:
-    """Tator kwargs for localization list/count (version, section, encoded_search, type)."""
+    """Tator kwargs for localization list/count (version, section, encoded_search, type).
+
+    When verified_only is True, adds an `attribute` filter for the localization's
+    own `verified::true` attribute so Tator excludes unverified localizations
+    server-side, instead of downloading everything and filtering client-side.
+    """
     kw: dict = {}
     if version_id is not None:
         kw["version"] = [version_id]
@@ -48,6 +54,8 @@ def localization_fetch_kwargs(
         kw["encoded_search"] = q
     if localization_type_id is not None:
         kw["type"] = [localization_type_id]
+    if verified_only:
+        kw["attribute"] = ["verified::true"]
     return kw
 
 
@@ -55,11 +63,22 @@ def media_fetch_kwargs(
     *,
     version_id: int | None = None,
     section_id: int | None = None,
+    verified_only: bool = False,
 ) -> dict:
-    """Tator kwargs for media list (version via related_attribute, section)."""
+    """Tator kwargs for media list (version via related_attribute, section).
+
+    When verified_only is True, adds `verified::true` to the `related_attribute`
+    filter so Tator only returns media with at least one verified localization,
+    instead of downloading all media and filtering client-side.
+    """
     kw: dict = {}
+    related_attribute: list[str] = []
     if version_id is not None:
-        kw["related_attribute"] = [f"$version::{version_id}"]
+        related_attribute.append(f"$version::{version_id}")
+    if verified_only:
+        related_attribute.append("verified::true")
+    if related_attribute:
+        kw["related_attribute"] = related_attribute
     if section_id is not None:
         kw["section"] = section_id
     return kw

--- a/tests/test_sync_filters.py
+++ b/tests/test_sync_filters.py
@@ -53,9 +53,32 @@ def test_localization_fetch_kwargs_strips_query():
     assert kw == {"encoded_search": "q"}
 
 
+def test_localization_fetch_kwargs_verified_only():
+    kw = localization_fetch_kwargs(version_id=3, verified_only=True)
+    assert kw == {"version": [3], "attribute": ["verified::true"]}
+
+
+def test_localization_fetch_kwargs_verified_only_false_omits_attribute():
+    kw = localization_fetch_kwargs(version_id=3, verified_only=False)
+    assert "attribute" not in kw
+
+
 def test_media_fetch_kwargs_version_and_section():
     kw = media_fetch_kwargs(version_id=5, section_id=2)
     assert kw == {"related_attribute": ["$version::5"], "section": 2}
+
+
+def test_media_fetch_kwargs_verified_only():
+    kw = media_fetch_kwargs(verified_only=True)
+    assert kw == {"related_attribute": ["verified::true"]}
+
+
+def test_media_fetch_kwargs_version_and_verified_only_combine():
+    kw = media_fetch_kwargs(version_id=5, section_id=2, verified_only=True)
+    assert kw == {
+        "related_attribute": ["$version::5", "verified::true"],
+        "section": 2,
+    }
 
 
 def test_scoped_data_dir_includes_filter_slug(tmp_path):

--- a/tests/test_verified_only_query_filters.py
+++ b/tests/test_verified_only_query_filters.py
@@ -1,0 +1,181 @@
+# fiftyone-sync, Apache-2.0 license
+# Filename: tests/test_verified_only_query_filters.py
+# Description: Tests that verified_only is pushed into the Tator media/localization
+# queries (related_attribute / attribute) so unverified data is never downloaded.
+
+import json
+
+from src.app import sync
+
+
+class _FakeMedia:
+    def __init__(self, media_id):
+        self.id = media_id
+
+
+class _FakeApi:
+    """Captures kwargs passed to get_media_list / get_localization_* calls."""
+
+    def __init__(self, media_ids=None, localizations=None):
+        self.media_ids = media_ids or []
+        self.localizations = localizations or []
+        self.get_media_list_calls: list[dict] = []
+        self.get_localization_count_calls: list[dict] = []
+        self.get_localization_list_calls: list[dict] = []
+
+    def get_media_list(self, project_id, **kwargs):
+        self.get_media_list_calls.append(kwargs)
+        return [_FakeMedia(mid) for mid in self.media_ids]
+
+    def get_localization_count(self, project_id, **kwargs):
+        self.get_localization_count_calls.append(kwargs)
+        return len(self.localizations)
+
+    def get_localization_list(self, project_id, **kwargs):
+        self.get_localization_list_calls.append(kwargs)
+        if kwargs.get("after") is not None:
+            return []
+        return list(self.localizations)
+
+
+def test_fetch_project_media_ids_verified_only_sets_related_attribute(monkeypatch):
+    fake_api = _FakeApi(media_ids=[1, 2])
+    monkeypatch.setattr(sync.tator, "get_api", lambda *_a, **_k: fake_api)
+
+    media_ids = sync.fetch_project_media_ids(
+        "http://tator.example", "tok", project_id=7, verified_only=True
+    )
+
+    assert media_ids == [1, 2]
+    assert fake_api.get_media_list_calls == [{"related_attribute": ["verified::true"]}]
+
+
+def test_fetch_project_media_ids_default_omits_related_attribute(monkeypatch):
+    fake_api = _FakeApi(media_ids=[1])
+    monkeypatch.setattr(sync.tator, "get_api", lambda *_a, **_k: fake_api)
+
+    sync.fetch_project_media_ids("http://tator.example", "tok", project_id=7)
+
+    assert fake_api.get_media_list_calls == [{}]
+
+
+def test_fetch_project_media_ids_combines_version_and_verified_only(monkeypatch):
+    fake_api = _FakeApi(media_ids=[1])
+    monkeypatch.setattr(sync.tator, "get_api", lambda *_a, **_k: fake_api)
+
+    sync.fetch_project_media_ids(
+        "http://tator.example",
+        "tok",
+        project_id=7,
+        version_id=21,
+        verified_only=True,
+    )
+
+    assert fake_api.get_media_list_calls == [
+        {"related_attribute": ["$version::21", "verified::true"]}
+    ]
+
+
+class _FakeLoc:
+    def __init__(self, loc_id, elemental_id, verified):
+        self.id = loc_id
+        self._data = {
+            "id": loc_id,
+            "elemental_id": elemental_id,
+            "attributes": {"verified": verified},
+        }
+
+    def to_dict(self):
+        return self._data
+
+
+def test_fetch_and_save_localizations_verified_only_sets_attribute_filter(
+    monkeypatch, tmp_path
+):
+    verified_loc = _FakeLoc(1, "eid-verified", True)
+    fake_api = _FakeApi(localizations=[verified_loc])
+    monkeypatch.setattr(
+        sync,
+        "_localizations_jsonl_path",
+        lambda *_a, **_k: str(tmp_path / "localizations.jsonl"),
+    )
+
+    out_path = sync.fetch_and_save_localizations(
+        fake_api, project_id=7, verified_only=True
+    )
+
+    # Both the count check and the paginated list call should carry the filter.
+    assert all(
+        kw.get("attribute") == ["verified::true"]
+        for kw in fake_api.get_localization_count_calls
+    )
+    assert any(
+        kw.get("attribute") == ["verified::true"]
+        for kw in fake_api.get_localization_list_calls
+    )
+
+    with open(out_path) as f:
+        lines = [json.loads(line) for line in f if line.strip()]
+    assert [line["elemental_id"] for line in lines] == ["eid-verified"]
+
+
+def test_fetch_and_save_localizations_default_omits_attribute_filter(
+    monkeypatch, tmp_path
+):
+    fake_api = _FakeApi(localizations=[_FakeLoc(1, "eid-1", False)])
+    monkeypatch.setattr(
+        sync,
+        "_localizations_jsonl_path",
+        lambda *_a, **_k: str(tmp_path / "localizations.jsonl"),
+    )
+
+    sync.fetch_and_save_localizations(fake_api, project_id=7)
+
+    assert all(
+        "attribute" not in kw for kw in fake_api.get_localization_count_calls
+    )
+    assert all(
+        "attribute" not in kw for kw in fake_api.get_localization_list_calls
+    )
+
+
+def test_resolve_localizations_jsonl_forwards_verified_only(monkeypatch, tmp_path):
+    """verified_only must reach both the media-id and localization fetch calls."""
+    captured = {}
+
+    def _fake_fetch_project_media_ids(*_args, **kwargs):
+        captured["media_kwargs"] = kwargs
+        return [1]
+
+    def _fake_fetch_and_save_localizations(*_args, **kwargs):
+        captured["loc_kwargs"] = kwargs
+        path = tmp_path / "localizations.jsonl"
+        path.write_text("")
+        return str(path)
+
+    monkeypatch.setattr(
+        sync, "fetch_project_media_ids", _fake_fetch_project_media_ids
+    )
+    monkeypatch.setattr(
+        sync, "fetch_and_save_localizations", _fake_fetch_and_save_localizations
+    )
+    monkeypatch.setattr(
+        sync,
+        "_localizations_jsonl_path",
+        lambda *_a, **_k: str(tmp_path / "does_not_exist.jsonl"),
+    )
+
+    sync._resolve_localizations_jsonl(
+        object(),
+        project_id=7,
+        version_id=None,
+        api_url="http://tator.example",
+        token="tok",
+        force_sync=True,
+        media_id_batch_size=100,
+        localization_batch_size=100,
+        verified_only=True,
+    )
+
+    assert captured["media_kwargs"].get("verified_only") is True
+    assert captured["loc_kwargs"].get("verified_only") is True


### PR DESCRIPTION
## Summary

When `verified_only` is enabled, filter Tator media/localization queries server-side instead of downloading everything and filtering after the fact.

- **Media query**: adds `verified::true` to the `related_attribute` filter (alongside the existing `$version::{id}` entry), so `get_media_list` only returns media with at least one verified localization.
- **Localization query**: adds `attribute=["verified::true"]` to the localization list/count kwargs, so `get_localization_list`/`get_localization_count` only return verified localizations.

Previously `verified_only` only affected which crops became FiftyOne dataset samples in `build_fiftyone_dataset_from_crops`/`reconcile_dataset_with_tator` — the media and localizations were still fully downloaded and cropped regardless. Now unverified media/localizations are never fetched, downloaded, or cropped, which meaningfully reduces data transfer and disk/CPU usage for `verified_only` syncs.

## Changes

- `src/app/sync_filters.py`: `media_fetch_kwargs` / `localization_fetch_kwargs` accept a new `verified_only` param.
- `src/app/sync.py`: threads `verified_only` through `fetch_project_media_ids` → `_media_fetch_kwargs`, `fetch_and_save_localizations`/`_get_localization_count_from_api` → `_localization_fetch_kwargs`, and through `_resolve_localizations_jsonl` → `_run_crop_pipeline` → `sync_project_to_fiftyone` (which already had `verified_only` but wasn't forwarding it into the crop pipeline). Also wired into the `main()` CLI entrypoint via config.
- `README.md`: documents the server-side filtering behavior for `verified_only`.
- Tests: `tests/test_sync_filters.py` (kwargs), `tests/test_verified_only_query_filters.py` (end-to-end kwarg propagation through the fetch functions).

The existing client-side filter in `build_fiftyone_dataset_from_crops`/`reconcile_dataset_with_tator` (`tests/test_verified_only_filter.py`) is unchanged and still acts as a defense-in-depth safety net.

## Testing

```
python -m pytest tests/ -q
```
116 passed.