### PR TITLE
fix(app): request presigned media URLs when downloading from Tator

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -247,6 +247,11 @@ the raw downloaded file. Existing non-empty crop files are reused even when the
 crop manifest is missing or stale; localizations are recropped when their
 recorded modification time changes.
 
+Media fetched for download are requested with presigned URLs (`presigned=86400`,
+`no_cache=true`), so media stored in an object store can be downloaded directly.
+Tator deployments that do not support presigning fall back to unsigned object
+keys automatically (a warning is logged).
+
 Labels come from `attributes.Label` (or `attributes.label`) in localizations.
 
 **Crop/download tuning** (set on the sync service; restart to apply):

--- a/src/app/sync.py
+++ b/src/app/sync.py
@@ -74,6 +74,10 @@ _DEFAULT_LOCALIZATION_BATCH_SIZE = 5000
 # Each media_id in query string is ~17 bytes; base URL + version ~500; 150 * 17 + 500 < 4094.
 _MAX_SAFE_MEDIA_ID_BATCH_SIZE = 150
 
+# Lifetime (seconds) of presigned media URLs requested from Tator. 86400 is the
+# maximum Tator allows; downloads can start hours after the media list is fetched.
+PRESIGN_EXPIRATION = 86400
+
 # sync_edits_to_tator: batch LocalizationList PUT/PATCH (elemental_ids / bulk update).
 # Chunk sizes are tunable via env vars so production can throttle bursts that would
 # otherwise overwhelm the Tator API (defaults reduced from 500 to 100/100).
@@ -411,15 +415,41 @@ def fetch_project_media_ids(
     return media_ids
 
 
+def _get_media_list_presigned(
+    api: Any, project_id: int, media_ids: list[int]
+) -> list[Any]:
+    """
+    Get Media for the given ids with presigned media file URLs.
+
+    Object-store backed deployments return unsigned object keys unless presigning
+    is requested, and downloading those fails with 403. Tator versions without
+    presign support fall back to the unsigned response.
+    """
+    try:
+        return api.get_media_list_by_id(
+            project_id,
+            {"ids": media_ids},
+            presigned=PRESIGN_EXPIRATION,
+            no_cache=True,
+        )
+    except Exception as e:
+        logger.warning(
+            f"Could not presign media URLs ({e}); falling back to unsigned object keys"
+        )
+        return api.get_media_list_by_id(project_id, {"ids": media_ids})
+
+
 def get_media_chunked(
     api: Any,
     project_id: int,
     media_ids: list[int],
     media_id_batch_size: int | None = None,
+    presigned: bool = False,
 ) -> list[Any]:
     """
     Get media objects in chunks. Uses get_media_list_by_id for reliable Media objects.
     Filters out non-Media responses (API quirk). Returns list of tator.models.Media.
+    Set presigned=True when the media files will be downloaded.
     """
     chunk_size = (
         media_id_batch_size
@@ -436,7 +466,11 @@ def get_media_chunked(
     all_media = []
     for start in range(0, len(media_ids), chunk_size):
         chunk_ids = media_ids[start : start + chunk_size]
-        media = api.get_media_list_by_id(project_id, {"ids": chunk_ids})
+        media = (
+            _get_media_list_presigned(api, project_id, chunk_ids)
+            if presigned
+            else api.get_media_list_by_id(project_id, {"ids": chunk_ids})
+        )
         new_media = [m for m in media if isinstance(m, tator.models.Media)]
         all_media += new_media
         logger.info(
@@ -2622,7 +2656,11 @@ def _run_crop_pipeline(
                 len(media_ids_list),
             )
             media_for_crop = get_media_chunked(
-                api, project_id, needed_ids, media_id_batch_size=media_id_batch_size
+                api,
+                project_id,
+                needed_ids,
+                media_id_batch_size=media_id_batch_size,
+                presigned=True,
             )
             if not media_for_crop:
                 logger.info(
@@ -5265,7 +5303,11 @@ def main() -> None:
         if media_ids and media_ids_needed:
             needed_ids = [mid for mid in media_ids if mid in media_ids_needed]
             all_media_cli = get_media_chunked(
-                api, project_id, needed_ids, media_id_batch_size=media_id_batch_size_cli
+                api,
+                project_id,
+                needed_ids,
+                media_id_batch_size=media_id_batch_size_cli,
+                presigned=True,
             )
             if all_media_cli:
                 save_media_to_tmp(

--- a/tests/test_media_presign.py
+++ b/tests/test_media_presign.py
@@ -1,0 +1,54 @@
+# fiftyone-sync, Apache-2.0 license
+# Filename: tests/test_media_presign.py
+# Description: Tests that media fetched for download asks Tator for presigned URLs
+# and falls back to unsigned object keys when presigning is unsupported.
+
+import src.app.sync as sync
+
+
+class _FakeMedia(sync.tator.models.Media):
+    def __init__(self, mid):
+        self.id = mid
+
+
+class _FakeApi:
+    """Records get_media_list_by_id kwargs; optionally rejects presigned requests."""
+
+    def __init__(self, media_ids, presign_supported=True):
+        self.media_ids = media_ids
+        self.presign_supported = presign_supported
+        self.calls: list[dict] = []
+
+    def get_media_list_by_id(self, project_id, media_id_query, **kwargs):
+        self.calls.append(kwargs)
+        if kwargs.get("presigned") is not None and not self.presign_supported:
+            raise RuntimeError("presigned unsupported")
+        return [_FakeMedia(mid) for mid in media_id_query["ids"]]
+
+
+def test_get_media_chunked_presigned_requests_signed_urls():
+    api = _FakeApi(media_ids=[1, 2])
+
+    media = sync.get_media_chunked(api, 7, [1, 2], presigned=True)
+
+    assert [m.id for m in media] == [1, 2]
+    assert api.calls == [
+        {"presigned": sync.PRESIGN_EXPIRATION, "no_cache": True}
+    ]
+
+
+def test_get_media_chunked_falls_back_to_unsigned_urls():
+    api = _FakeApi(media_ids=[1], presign_supported=False)
+
+    media = sync.get_media_chunked(api, 7, [1], presigned=True)
+
+    assert [m.id for m in media] == [1]
+    assert api.calls == [{"presigned": sync.PRESIGN_EXPIRATION, "no_cache": True}, {}]
+
+
+def test_get_media_chunked_default_does_not_presign():
+    api = _FakeApi(media_ids=[1])
+
+    sync.get_media_chunked(api, 7, [1])
+
+    assert api.calls == [{}]


### PR DESCRIPTION
## Problem

Media objects fetched for the download/crop step came back with **unsigned object keys** in `media_files`, so `tator.util.download_media` could not fetch them from object-store backed deployments (403), surfacing as repeated `Could not download <name> after 3 tries` warnings.

## Fix

`get_media_chunked` now takes `presigned: bool` and, when set, asks Tator for presigned URLs (`presigned=PRESIGN_EXPIRATION` = 86400s, Tator's max; `no_cache=True`). If the deployment doesn't support presigning, the call falls back to the plain unsigned request and logs a warning, so behavior is unchanged for those servers.

`presigned=True` is passed only at the two call sites whose media actually get downloaded:

- `_run_crop_pipeline` (service/worker sync + crop recompute)
- `main()` (CLI sync path)

The attribute-only lookups (`_build_media_attributes_map`, classification media) keep the cheaper unsigned request since they never touch media files.

## Tests

`tests/test_media_presign.py` covers the presigned request kwargs, the fallback to unsigned keys, and that the default path does not presign.

`python -m pytest -q` → 115 passed, 9 skipped. The 3 errors in `tests/test_export_dataset_csv.py` are pre-existing locally (they need a running MongoDB/FiftyOne service).

## Docs

`docs/USAGE.md` data-layout section notes the presigned download behavior and the fallback.